### PR TITLE
Add manually-triggered build workflow for cross-platform releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Build Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: 'Version label for the build (e.g. alpha-1, beta-2)'
+        required: false
+        default: ''
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            dist_cmd: dist:linux
+          - os: macos-latest
+            dist_cmd: dist:mac
+          - os: windows-latest
+            dist_cmd: dist:win
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Cache Electron
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-electron-cache
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build distributable
+        run: npm run ${{ matrix.dist_cmd }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: astra-${{ runner.os }}${{ inputs.version_tag && format('-{0}', inputs.version_tag) || '' }}
+          path: |
+            dist/*.exe
+            dist/*.dmg
+            dist/*.zip
+            dist/*.AppImage
+            dist/*.deb
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
Adds a workflow_dispatch workflow that builds distributable packages (NSIS/portable for Windows, DMG/zip for macOS, AppImage/deb for Linux) and uploads them as downloadable artifacts. Supports an optional version label input for tagging alpha/beta builds.