### PR TITLE
Fix cross-platform build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "build:native": "cd native && node-gyp rebuild",
     "rebuild:native": "cd native && node-gyp rebuild --target=$(node -p \"require('electron/package.json').version\") --arch=$(node -p \"process.arch\") --dist-url=https://electronjs.org/headers",
     "postinstall": "npm run rebuild:native || echo 'Native build failed, will use JS fallback'",
-    "dist": "npm run build && electron-builder",
-    "dist:win": "npm run build && electron-builder --win",
-    "dist:mac": "npm run build && electron-builder --mac",
-    "dist:linux": "npm run build && electron-builder --linux"
+    "dist": "npm run build && electron-builder --publish never",
+    "dist:win": "npm run build && electron-builder --win --publish never",
+    "dist:mac": "npm run build && electron-builder --mac --publish never",
+    "dist:linux": "npm run build && electron-builder --linux --publish never"
   },
   "repository": {
     "type": "git",
@@ -27,7 +27,10 @@
     "visualizer",
     "electron"
   ],
-  "author": "",
+  "author": {
+    "name": "Astra",
+    "email": "astra@users.noreply.github.com"
+  },
   "license": "MIT",
   "dependencies": {
     "music-metadata": "^11.10.6",


### PR DESCRIPTION
- Add author email to package.json (required for Linux .deb maintainer field)
- Add --publish never to all dist scripts to prevent electron-builder from requiring a GH_TOKEN for GitHub Releases publishing

https://claude.ai/code/session_01VHoGdWqrge79eR6FnqxLf7