### PR TITLE
Fix AudioWorklet blocked by CSP in production builds

### DIFF
--- a/electron-vite.config.ts
+++ b/electron-vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()]
   },
   renderer: {
-    plugins: [react()]
+    plugins: [react()],
+    build: {
+      assetsInlineLimit: 0
+    }
   }
 })


### PR DESCRIPTION
Vite inlines small assets as base64 data: URIs, which violates the Content-Security-Policy script-src 'self' directive. Setting assetsInlineLimit to 0 forces the worklet to be emitted as a separate file, giving it a proper URL that satisfies the CSP.

https://claude.ai/code/session_01VHoGdWqrge79eR6FnqxLf7