### PR TITLE
Move AudioWorklet to public/ to fix CSP violation in production

### DIFF
--- a/public/oscilloscope-worklet.js
+++ b/public/oscilloscope-worklet.js
@@ -3,7 +3,7 @@
 // Feeds samples to native C++ visualizers via main thread
 
 class OscilloscopeProcessor extends AudioWorkletProcessor {
-  process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean {
+  process(inputs, outputs, parameters) {
     const input = inputs[0]
     if (!input || input.length === 0) return true
 
@@ -14,12 +14,8 @@ class OscilloscopeProcessor extends AudioWorkletProcessor {
     if (!leftChannel || leftChannel.length === 0) return true
 
     // Send stereo audio samples to main thread for native C++ processing
-    // Main thread will:
-    // - Feed left channel to oscilloscope
-    // - Feed stereo to vectorscope
-    // - Feed mono sum to spectrum analyzer
     this.port.postMessage({
-      left: leftChannel.slice(),  // Copy to avoid race conditions
+      left: leftChannel.slice(),
       right: rightChannel.slice()
     })
 

--- a/src/renderer/audio/AudioEngine.ts
+++ b/src/renderer/audio/AudioEngine.ts
@@ -1,5 +1,4 @@
 import { PlaybackState, EQBand } from '../types/audio'
-import workletUrl from './oscilloscope-worklet.ts?url'
 
 type EventCallback = (...args: unknown[]) => void
 
@@ -109,7 +108,7 @@ export class AudioEngine {
       // Load and create AudioWorklet for real-time analysis
       if (!this.workletLoaded) {
         try {
-          await this.context.audioWorklet.addModule(workletUrl)
+          await this.context.audioWorklet.addModule('./oscilloscope-worklet.js')
           this.workletLoaded = true
         } catch (err) {
           console.error('Failed to load audio worklet:', err)


### PR DESCRIPTION
The ?url import on a .ts file causes Vite to compile and inline it as a base64 data: URI regardless of assetsInlineLimit. This violates the CSP script-src 'self' directive in production builds.

Fix: move the worklet to public/ as plain JS so it's served as a separate file at a 'self' origin URL, bypassing Vite's asset pipeline.

https://claude.ai/code/session_01VHoGdWqrge79eR6FnqxLf7