### PR TITLE
fix: Discord RPC silently fails on socket disconnection

### DIFF
--- a/src/main/services/discordRpc.ts
+++ b/src/main/services/discordRpc.ts
@@ -345,13 +345,16 @@ export class DiscordRpcService {
   private sendPendingPresence(force = false): void {
     const activity = this.buildActivityFromPresence(this.pendingPresence)
     const signature = JSON.stringify(activity)
-    if (!force && signature === this.lastPresenceSignature) return
-    
-    // Only send if socket is actually alive
-    if (!this.socket || this.socket.destroyed) {
-      return // Will retry on reconnect, pendingPresence is preserved
+    const socket = this.socket
+    if (!socket || socket.destroyed) {
+      this.ready = false
+      if (this.enabled) {
+        void this.ensureConnected()
+        this.scheduleReconnect()
+      }
+      return
     }
-    
+    if (!force && signature === this.lastPresenceSignature) return
     if (this.sendSetActivity(activity)) {
       this.lastPresenceSignature = signature
     }

--- a/src/main/services/discordRpc.ts
+++ b/src/main/services/discordRpc.ts
@@ -346,6 +346,12 @@ export class DiscordRpcService {
     const activity = this.buildActivityFromPresence(this.pendingPresence)
     const signature = JSON.stringify(activity)
     if (!force && signature === this.lastPresenceSignature) return
+    
+    // Only send if socket is actually alive
+    if (!this.socket || this.socket.destroyed) {
+      return // Will retry on reconnect, pendingPresence is preserved
+    }
+    
     if (this.sendSetActivity(activity)) {
       this.lastPresenceSignature = signature
     }


### PR DESCRIPTION
- Add explicit socket health check before sending presence
- Preserve pendingPresence during reconnection
- Retry flushing presence data when socket recovers
- Prevents data loss if Discord briefly disconnects

Fixes scenario where RPC activity updates are silently dropped if the IPC socket closes between ready check and send.