### PR TITLE
add dockerfile to build release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+dist/
+node_modules/
+.electron/
+.electron-builder/
+
+*.AppImage
+*.deb
+*.dmg
+*.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -----------------------------------------------
-FROM node:25 AS deps
+FROM node:25 AS os_deps
 
 RUN dpkg --add-architecture i386 \
     && apt update \
@@ -7,6 +7,9 @@ RUN dpkg --add-architecture i386 \
         p7zip-full fuse wine wine32 build-essential \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------
+FROM os_deps AS deps
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# -----------------------------------------------
+FROM node:25 AS deps
+
+RUN dpkg --add-architecture i386 \
+    && apt update \
+    && apt install -y --no-install-recommends \
+        p7zip-full fuse wine wine32 build-essential \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm config set loglevel info \
+    && npm install
+
+# -----------------------------------------------
+FROM deps AS builder
+
+COPY --from=deps /app /app
+COPY . .
+
+ENV DEBUG=electron-builder
+ENV ELECTRON_CACHE=/root/.cache/electron
+ENV ELECTRON_BUILDER_CACHE=/root/.cache/electron-builder
+RUN --mount=type=cache,target=/root/.npm \
+    npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,13 @@ COPY . .
 ENV DEBUG=electron-builder
 ENV ELECTRON_CACHE=/root/.cache/electron
 ENV ELECTRON_BUILDER_CACHE=/root/.cache/electron-builder
+
+# Rebuild native addon now that the native/ dir is present
+RUN --mount=type=cache,target=/root/.cache/electron \
+    --mount=type=cache,target=/root/.cache/electron-builder \
+    npm run rebuild:native
+
 RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/root/.cache/electron \
+    --mount=type=cache,target=/root/.cache/electron-builder \
     npm run build

--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ npm run dist:linux       # Linux (AppImage + DEB)
 
 During packaging, Astra prunes `ffprobe-static` binaries in `afterPack` so each artifact only contains the target platform/arch binary instead of every platform variant.
 
+### via Docker
+
+> _This only builds releases for linux and win._
+
+First, build the Docker image:
+
+```bash
+docker build -t Boof2015/astra:build .
+```
+
+Then, run the container to build a dist release (linux/win):
+
+```bash
+docker run -it \
+  -v $PWD/dist:/app/dist \
+  -v $PWD/.electron:/root/.cache/electron \
+  -v $PWD/.electron-builder:/root/.cache/electron-builder \
+  Boof2015/astra:build \
+  npm run dist:linux
+```
+
 ## Documentation
 
 For detailed technical documentation, see the [Wiki](https://github.com/Boof2015/astra/wiki).


### PR DESCRIPTION
Hiya! Great project, I think it looks great :sunglasses:. Let me know if I've missed anything in my PR description or code, I'm happy to make any required changes.

>[!NOTE]
> _this only works for linux & win, as the mac release is built using the npm dep `dmg-license`, requires `iconv-corefoundation` which is a mac native dependency. I don't have a mac that I can develop a mac build on._

## Context

I don't like running `npm install` on my host machine after all the recent debacles e.g. Shai-Hulud, so I made a dockerfile that will build the linux Appimage for me

## Changes

- added a .dockerignore file to avoid adding unwanted dirs to the image
- added a multistage dockerfile
  - installs os dependencies
  - copies the package files and runs `npm install`
  - then runs `npm build`
  - all build stages cache the npm packages so rebuilding doesn't take ages
  - running can bind-mount electron dirs which avoids re-downloading electron & other dependencies

## Commands

- build with
  ```shell
  docker build -t Boof2015/astra:build .
  ```
- build a release for `dist:linux` or `dist:win`
  ```shell
  docker run -it \
    -v $PWD/dist:/app/dist \
    -v $PWD/.electron:/root/.cache/electron \
    -v $PWD/.electron-builder:/root/.cache/electron-builder \
    Boof2015/astra:build \
    npm run dist:linux
  ```