### PR TITLE
security: fix file access validation, SQL injection, and weak RNG

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3128,17 +3128,53 @@ ipcMain.handle('dialog:openFile', async (_event, options: {
   return result.filePaths[0]
 })
 
-ipcMain.handle('fs:readTextFile', async (_event, filePath: string) => {
+const FS_READ_TEXT_ALLOWED_EXTENSIONS = new Set([
+  '.json', '.txt', '.lrc', '.csv', '.m3u', '.m3u8', '.xspf', '.wpl', '.asx'
+])
+const FS_READ_IMAGE_ALLOWED_EXTENSIONS = new Set([
+  '.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.tiff', '.avif'
+])
+const FS_WRITE_ALLOWED_EXTENSIONS = new Set(['.json', '.txt', '.lrc', '.csv'])
+const FS_WRITE_MAX_BYTES = 10 * 1024 * 1024 // 10 MB
+
+ipcMain.handle('fs:readTextFile', async (_event, filePath: unknown) => {
+  if (typeof filePath !== 'string' || filePath.trim().length === 0) {
+    throw new Error('Invalid file path.')
+  }
+  const ext = extname(filePath).toLowerCase()
+  if (!FS_READ_TEXT_ALLOWED_EXTENSIONS.has(ext)) {
+    throw new Error(`File type not permitted for reading: ${ext || '(none)'}`)
+  }
   return readFile(filePath, 'utf-8')
 })
 
-ipcMain.handle('fs:readDataUrl', async (_event, filePath: string) => {
+ipcMain.handle('fs:readDataUrl', async (_event, filePath: unknown) => {
+  if (typeof filePath !== 'string' || filePath.trim().length === 0) {
+    throw new Error('Invalid file path.')
+  }
+  const ext = extname(filePath).toLowerCase()
+  if (!FS_READ_IMAGE_ALLOWED_EXTENSIONS.has(ext)) {
+    throw new Error(`File type not permitted for reading: ${ext || '(none)'}`)
+  }
   const data = await readFile(filePath)
   if (data.length === 0) return null
   return toDataUrl(detectArtworkMimeType(filePath.toLowerCase(), data), data)
 })
 
-ipcMain.handle('fs:writeTextFile', async (_event, filePath: string, content: string) => {
+ipcMain.handle('fs:writeTextFile', async (_event, filePath: unknown, content: unknown) => {
+  if (typeof filePath !== 'string' || filePath.trim().length === 0) {
+    throw new Error('Invalid file path.')
+  }
+  if (typeof content !== 'string') {
+    throw new Error('Invalid content.')
+  }
+  const ext = extname(filePath).toLowerCase()
+  if (!FS_WRITE_ALLOWED_EXTENSIONS.has(ext)) {
+    throw new Error(`File type not permitted for writing: ${ext || '(none)'}`)
+  }
+  if (Buffer.byteLength(content, 'utf-8') > FS_WRITE_MAX_BYTES) {
+    throw new Error('Content exceeds maximum allowed size.')
+  }
   await writeFile(filePath, content, 'utf-8')
   return true
 })

--- a/src/main/services/library.ts
+++ b/src/main/services/library.ts
@@ -5550,8 +5550,11 @@ export function getPlaylistTracks(playlistId: number): DbTrack[] {
 export async function addToPlaylist(playlistId: number, trackPaths: string[]): Promise<void> {
   if (!db || trackPaths.length === 0) return
   // Get current max position
-  const result = db.exec(`SELECT COALESCE(MAX(position), -1) as max_pos FROM playlist_tracks WHERE playlist_id = ${playlistId}`)
-  let position = (result[0].values[0][0] as number) + 1
+  const maxStmt = db.prepare('SELECT COALESCE(MAX(position), -1) as max_pos FROM playlist_tracks WHERE playlist_id = ?')
+  maxStmt.bind([playlistId])
+  const maxPos = maxStmt.step() ? (maxStmt.get()[0] as number) : -1
+  maxStmt.free()
+  let position = maxPos + 1
   const now = Date.now()
   for (const trackPath of trackPaths) {
     db.run(
@@ -5567,12 +5570,16 @@ export async function removeFromPlaylist(playlistId: number, trackPath: string):
   if (!db) return
   db.run('DELETE FROM playlist_tracks WHERE playlist_id = ? AND track_path = ?', [playlistId, trackPath])
   // Reorder positions
-  const result = db.exec(`SELECT id FROM playlist_tracks WHERE playlist_id = ${playlistId} ORDER BY position`)
-  if (result.length > 0) {
-    result[0].values.forEach((row: unknown[], i: number) => {
-      db!.run('UPDATE playlist_tracks SET position = ? WHERE id = ?', [i, row[0]])
-    })
+  const idStmt = db.prepare('SELECT id FROM playlist_tracks WHERE playlist_id = ? ORDER BY position')
+  idStmt.bind([playlistId])
+  const idRows: unknown[][] = []
+  while (idStmt.step()) {
+    idRows.push(idStmt.get())
   }
+  idStmt.free()
+  idRows.forEach((row, i) => {
+    db!.run('UPDATE playlist_tracks SET position = ? WHERE id = ?', [i, row[0]])
+  })
   db.run('UPDATE playlists SET updated_at = ? WHERE id = ?', [Date.now(), playlistId])
   await saveDatabase()
 }

--- a/src/main/services/subsonic.ts
+++ b/src/main/services/subsonic.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto'
+import { createHash, randomBytes } from 'crypto'
 
 const SUBSONIC_API_VERSION = '1.16.1'
 const SUBSONIC_CLIENT_ID = 'astra'
@@ -201,7 +201,7 @@ function buildAuthQuery(
     throw new Error('Password is required.')
   }
 
-  const salt = Math.random().toString(36).slice(2, 12)
+  const salt = randomBytes(6).toString('hex')
   const token = createHash('md5').update(`${password}${salt}`).digest('hex')
 
   const query: Record<string, string> = {


### PR DESCRIPTION
- fs:readTextFile, fs:readDataUrl, fs:writeTextFile IPC handlers now validate filePath type and enforce extension allowlists, preventing arbitrary file reads/writes from a compromised renderer context. fs:writeTextFile also enforces a 10 MB content size cap.

- addToPlaylist and removeFromPlaylist in library.ts replaced direct template-literal interpolation of playlistId into db.exec() with db.prepare() + bind(), eliminating SQL injection risk.

- Subsonic auth salt generation replaced Math.random() with crypto.randomBytes() for a cryptographically secure salt.

Unfixed (architectural constraints):
- sandbox: false on all BrowserWindows (required for native .node module loading in preload)