### PR TITLE
Toggle on discord RPC between codec and Album name

### DIFF
--- a/src/main/services/discordRpc.ts
+++ b/src/main/services/discordRpc.ts
@@ -56,6 +56,7 @@ export interface DiscordPresenceUpdate {
 export interface DiscordRpcConfigureOptions {
   enabled: boolean
   coverArtEnabled?: boolean
+  showAlbumInHover?: boolean
 }
 
 export interface DiscordRpcConfigureResult {
@@ -112,6 +113,7 @@ function listDirectories(path: string): string[] {
 export class DiscordRpcService {
   private enabled = false
   private coverArtEnabled = false
+  private showAlbumInHover = false
   private socket: Socket | null = null
   private ready = false
   private receiveBuffer = Buffer.alloc(0)
@@ -125,10 +127,13 @@ export class DiscordRpcService {
   async configure(options: DiscordRpcConfigureOptions): Promise<DiscordRpcConfigureResult> {
     const nextEnabled = Boolean(options.enabled)
     const nextCoverArtEnabled = Boolean(options.coverArtEnabled)
+    const nextShowAlbumInHover = Boolean(options.showAlbumInHover)
     const enabledChanged = this.enabled !== nextEnabled
+    const settingsChanged = this.coverArtEnabled !== nextCoverArtEnabled || this.showAlbumInHover !== nextShowAlbumInHover
 
     this.enabled = nextEnabled
     this.coverArtEnabled = nextCoverArtEnabled
+    this.showAlbumInHover = nextShowAlbumInHover
 
     if (!this.enabled) {
       this.clearReconnectTimer()
@@ -148,6 +153,12 @@ export class DiscordRpcService {
     if (!this.fallbackLargeImageUrl) {
       void this.ensureFallbackLargeImageUrl()
     }
+
+    // Re-send presence if settings changed and we're connected
+    if (settingsChanged && connected && this.ready && this.pendingPresence) {
+      this.sendPendingPresence(true)
+    }
+
     if (connected) {
       return {
         ok: true,
@@ -427,7 +438,7 @@ export class DiscordRpcService {
   ): Record<string, unknown> | null {
     const coverArtUrl = this.coverArtEnabled ? normalizeHttpsUrl(presence?.track?.coverArtUrl) : undefined
     const largeImageUrl = coverArtUrl ?? this.fallbackLargeImageUrl ?? undefined
-    return buildDiscordActivityFromPresence(presence, { largeImageUrl })
+    return buildDiscordActivityFromPresence(presence, { largeImageUrl, showAlbumInHover: this.showAlbumInHover })
   }
 
   private async ensureFallbackLargeImageUrl(): Promise<void> {

--- a/src/main/services/discordRpcActivity.ts
+++ b/src/main/services/discordRpcActivity.ts
@@ -32,6 +32,7 @@ export interface DiscordActivityPresenceUpdate {
 
 export interface BuildDiscordActivityOptions {
   largeImageUrl?: string
+  showAlbumInHover?: boolean
   nowSeconds?: number
 }
 
@@ -98,7 +99,13 @@ function formatAudioLabel(value?: string): string | null {
   return /^[a-z0-9._+-]+$/i.test(normalized) ? normalized.toUpperCase() : normalized
 }
 
-function buildQualityLine(track: DiscordActivityTrackPresence): string | null {
+function buildHoverLine(track: DiscordActivityTrackPresence, showAlbum: boolean): string | null {
+  if (showAlbum) {
+    const album = normalizeText(track.album)
+    return album ? truncateDiscordField(album, 128) : null
+  }
+
+  // Show codec stats
   const parts: string[] = []
 
   if (track.isAtmosJoc) {
@@ -182,12 +189,12 @@ export function buildDiscordActivityFromPresence(
   }
 
   if (options.largeImageUrl) {
-    const qualityLine = buildQualityLine(presence.track)
+    const hoverLine = buildHoverLine(presence.track, Boolean(options.showAlbumInHover))
     activity.assets = {
       large_image: options.largeImageUrl
     }
-    if (qualityLine) {
-      activity.assets.large_text = truncateDiscordField(qualityLine, 128)
+    if (hoverLine) {
+      activity.assets.large_text = truncateDiscordField(hoverLine, 128)
     }
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -646,7 +646,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Integrations
   discord: {
-    configure: (options: { enabled: boolean; coverArtEnabled: boolean }): Promise<DiscordRpcConfigureResult> =>
+    configure: (options: { enabled: boolean; coverArtEnabled: boolean; showAlbumInHover?: boolean }): Promise<DiscordRpcConfigureResult> =>
       ipcRenderer.invoke('discord:configure', options),
     updatePresence: (update: DiscordPresenceUpdate) => ipcRenderer.send('discord:updatePresence', update),
     clearPresence: () => ipcRenderer.send('discord:clearPresence'),
@@ -1072,7 +1072,7 @@ declare global {
 
       // Integrations
       discord: {
-        configure: (options: { enabled: boolean; coverArtEnabled: boolean }) => Promise<DiscordRpcConfigureResult>
+        configure: (options: { enabled: boolean; coverArtEnabled: boolean; showAlbumInHover?: boolean }) => Promise<DiscordRpcConfigureResult>
         updatePresence: (update: DiscordPresenceUpdate) => void
         clearPresence: () => void
         resolveCoverArt: (query: DiscordCoverArtLookupQuery) => Promise<DiscordCoverArtLookupResult>

--- a/src/renderer/components/views/SettingsView.tsx
+++ b/src/renderer/components/views/SettingsView.tsx
@@ -271,9 +271,11 @@ export default function SettingsView() {
   const {
     enabled: discordEnabled,
     coverArtEnabled: discordCoverArtEnabled,
+    showAlbumInHover: discordShowAlbumInHover,
     statusMessage: discordStatusMessage,
     setEnabled: setDiscordEnabled,
     setCoverArtEnabled: setDiscordCoverArtEnabled,
+    setShowAlbumInHover: setDiscordShowAlbumInHover,
   } = useDiscordSettingsStore()
   const {
     status: localApiStatus,
@@ -1837,6 +1839,18 @@ export default function SettingsView() {
                       {discordCoverArtEnabled ? 'Enabled' : 'Disabled'}
                     </button>
                   </div>
+                  <label className="settings-field">
+                    <span className="settings-field-label">Show Album in Hover Tooltip</span>
+                    <select
+                      className="settings-select"
+                      value={discordShowAlbumInHover ? 'album' : 'codec'}
+                      onChange={(e) => void setDiscordShowAlbumInHover(e.target.value === 'album')}
+                      disabled={!discordEnabled}
+                    >
+                      <option value="codec">Codec Stats</option>
+                      <option value="album">Album</option>
+                    </select>
+                  </label>
                 </div>
                 <p className="settings-note">{discordStatusMessage}</p>
               </div>

--- a/src/renderer/stores/discordSettingsStore.ts
+++ b/src/renderer/stores/discordSettingsStore.ts
@@ -3,17 +3,20 @@ import { create } from 'zustand'
 interface DiscordSettingsStore {
   enabled: boolean
   coverArtEnabled: boolean
+  showAlbumInHover: boolean
   coverArtLookupActive: boolean
   statusMessage: string
   setCoverArtLookupActive: (coverArtLookupActive: boolean) => void
   setEnabled: (enabled: boolean) => Promise<void>
   setCoverArtEnabled: (enabled: boolean) => Promise<void>
+  setShowAlbumInHover: (showAlbumInHover: boolean) => Promise<void>
   initFromSaved: () => Promise<void>
   resetToDefaults: () => Promise<void>
 }
 
 const ENABLED_STORAGE_KEY = 'astra-discord-rpc-enabled'
 const COVER_ART_ENABLED_STORAGE_KEY = 'astra-discord-rpc-cover-art-enabled'
+const SHOW_ALBUM_IN_HOVER_STORAGE_KEY = 'astra-discord-rpc-show-album-in-hover'
 const COVER_ART_CACHE_STORAGE_KEY_V1 = 'astra-discord-cover-art-cache-v1'
 const COVER_ART_CACHE_STORAGE_KEY_V2 = 'astra-discord-cover-art-cache-v2'
 const COVER_ART_CACHE_STORAGE_KEY_V3 = 'astra-discord-cover-art-cache-v3'
@@ -26,10 +29,10 @@ export const useDiscordSettingsStore = create<DiscordSettingsStore>((set, get) =
   }
 
   const applyDiscordConfig = async () => {
-    const { enabled, coverArtEnabled } = get()
+    const { enabled, coverArtEnabled, showAlbumInHover } = get()
 
     try {
-      const result = await window.electronAPI.discord.configure({ enabled, coverArtEnabled })
+      const result = await window.electronAPI.discord.configure({ enabled, coverArtEnabled, showAlbumInHover })
       set({ statusMessage: result.message })
       if (!enabled) {
         window.electronAPI.discord.clearPresence()
@@ -43,6 +46,7 @@ export const useDiscordSettingsStore = create<DiscordSettingsStore>((set, get) =
   return {
     enabled: false,
     coverArtEnabled: false,
+    showAlbumInHover: false,
     coverArtLookupActive: false,
     statusMessage: 'Discord Rich Presence is disabled.',
 
@@ -62,18 +66,26 @@ export const useDiscordSettingsStore = create<DiscordSettingsStore>((set, get) =
       await applyDiscordConfig()
     },
 
+    setShowAlbumInHover: async (showAlbumInHover: boolean) => {
+      set({ showAlbumInHover })
+      localStorage.setItem(SHOW_ALBUM_IN_HOVER_STORAGE_KEY, showAlbumInHover ? '1' : '0')
+      await applyDiscordConfig()
+    },
+
     initFromSaved: async () => {
       clearLegacyClientId()
       const enabled = localStorage.getItem(ENABLED_STORAGE_KEY) === '1'
       const coverArtEnabled = localStorage.getItem(COVER_ART_ENABLED_STORAGE_KEY) === '1'
-      set({ enabled, coverArtEnabled, coverArtLookupActive: false })
+      const showAlbumInHover = localStorage.getItem(SHOW_ALBUM_IN_HOVER_STORAGE_KEY) === '1'
+      set({ enabled, coverArtEnabled, showAlbumInHover, coverArtLookupActive: false })
       await applyDiscordConfig()
     },
 
     resetToDefaults: async () => {
-      set({ enabled: false, coverArtEnabled: false, coverArtLookupActive: false })
+      set({ enabled: false, coverArtEnabled: false, showAlbumInHover: false, coverArtLookupActive: false })
       localStorage.removeItem(ENABLED_STORAGE_KEY)
       localStorage.removeItem(COVER_ART_ENABLED_STORAGE_KEY)
+      localStorage.removeItem(SHOW_ALBUM_IN_HOVER_STORAGE_KEY)
       localStorage.removeItem(COVER_ART_CACHE_STORAGE_KEY_V1)
       localStorage.removeItem(COVER_ART_CACHE_STORAGE_KEY_V2)
       localStorage.removeItem(COVER_ART_CACHE_STORAGE_KEY_V3)


### PR DESCRIPTION
Adds the ability to toggle the discord RPC tooltip between codec and album name

<img width="340" height="110" alt="image" src="https://github.com/user-attachments/assets/319bbce1-1d8b-4c1a-9b80-e3163f5482fe" />
<img width="346" height="119" alt="image" src="https://github.com/user-attachments/assets/44cad684-698f-4b26-8a44-3fc59113a10a" />
<img width="1304" height="293" alt="image" src="https://github.com/user-attachments/assets/9be6f08a-e479-4c65-add4-347baffb308b" />
