### PR TITLE
Fix parsing with Spotiflac

### DIFF
--- a/src/main/services/lyrics.ts
+++ b/src/main/services/lyrics.ts
@@ -134,18 +134,42 @@ async function resolveEmbeddedLyrics(trackPath: string): Promise<LyricsPayload |
     let plainLyrics: string | null = null
     let bestSyncedLines: LyricsLine[] = []
     for (const lyricTag of lyricTags) {
+      // Get unsynchronized lyrics (normalized)
       if (!plainLyrics) {
         plainLyrics = normalizeLyricsText(lyricTag.text)
       }
 
-      const syncedLines = sanitizeSyncLines(lyricTag.syncText)
+      // Try synchronized lyrics from syncText
+      let syncedLines = sanitizeSyncLines(lyricTag.syncText)
+      // If syncText didn't yield lines, try to parse the unsynchronized text as LRC/XLRC
+      if (syncedLines.length === 0 && plainLyrics) {
+        // Attempt to parse as LRC
+        const lrcPayload = parseLyricsText(plainLyrics, 'embedded', 'lrc')
+        if (lrcPayload && lrcPayload.syncedLines.length > 0) {
+          syncedLines = lrcPayload.syncedLines
+        } else {
+          // Attempt to parse as XLRC
+          const xlrcPayload = parseLyricsText(plainLyrics, 'embedded', 'xlrc')
+          if (xlrcPayload && xlrcPayload.syncedLines.length > 0) {
+            syncedLines = xlrcPayload.syncedLines
+          }
+        }
+      }
+
       if (syncedLines.length > bestSyncedLines.length) {
         bestSyncedLines = syncedLines
       }
     }
 
     const syncedLyrics = toPlainLyricsFromLines(bestSyncedLines)
-    return createLyricsPayload('embedded', null, bestSyncedLines.length > 0 ? 'lrc' : 'plain', plainLyrics, syncedLyrics, bestSyncedLines)
+    return createLyricsPayload(
+      'embedded',
+      null,
+      bestSyncedLines.length > 0 ? 'lrc' : 'plain',
+      plainLyrics,
+      syncedLyrics,
+      bestSyncedLines
+    )
   } catch {
     return null
   }

--- a/src/renderer/components/layout/TransportLyricsShelf.tsx
+++ b/src/renderer/components/layout/TransportLyricsShelf.tsx
@@ -190,6 +190,22 @@ export default function TransportLyricsShelf() {
     </div>
   )
 
+  const getPlainLyricsPreview = (plainLyrics: string): string => {
+    if (!plainLyrics) return ''
+    // Take first non-empty line, trim, and collapse internal whitespace
+    const lines = plainLyrics.split(/\r?\n/)
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (trimmed) {
+        // Collapse multiple spaces
+        const collapsed = trimmed.replace(/\s+/g, ' ')
+        // Limit length to 100 chars
+        return collapsed.length > 100 ? collapsed.substring(0, 100) + '…' : collapsed
+      }
+    }
+    return ''
+  }
+
   const renderBody = () => {
     if (!lyricsShelfExpanded) {
       if (bodyState.kind === 'hit_synced') {
@@ -197,6 +213,14 @@ export default function TransportLyricsShelf() {
       }
       if (bodyState.kind === 'no-track' || bodyState.kind === 'loading') {
         return <p className="transport-lyrics-shelf-state">{bodyState.message}</p>
+      }
+      if (bodyState.kind === 'hit_plain') {
+        const preview = getPlainLyricsPreview(bodyState.plainLyrics)
+        return (
+          <p className="transport-lyrics-shelf-state transport-lyrics-shelf-state-plain">
+            {preview}
+          </p>
+        )
       }
       if (bodyState.kind === 'transient_error') {
         return (

--- a/src/renderer/components/popout/LyricsPopoutApp.tsx
+++ b/src/renderer/components/popout/LyricsPopoutApp.tsx
@@ -229,6 +229,22 @@ export default function LyricsPopoutApp() {
     </div>
   )
 
+  const getPlainLyricsPreview = (plainLyrics: string): string => {
+    if (!plainLyrics) return ''
+    // Take first non-empty line, trim, and collapse internal whitespace
+    const lines = plainLyrics.split(/\r?\n/)
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (trimmed) {
+        // Collapse multiple spaces
+        const collapsed = trimmed.replace(/\s+/g, ' ')
+        // Limit length to 100 chars
+        return collapsed.length > 100 ? collapsed.substring(0, 100) + '…' : collapsed
+      }
+    }
+    return ''
+  }
+
   const renderBody = () => {
     if (!isExpanded) {
       if (bodyState.kind === 'hit_synced') {
@@ -236,6 +252,14 @@ export default function LyricsPopoutApp() {
       }
       if (bodyState.kind === 'no-track' || bodyState.kind === 'loading') {
         return <p className="transport-lyrics-shelf-state">{bodyState.message}</p>
+      }
+      if (bodyState.kind === 'hit_plain') {
+        const preview = getPlainLyricsPreview(bodyState.plainLyrics)
+        return (
+          <p className="transport-lyrics-shelf-state transport-lyrics-shelf-state-plain">
+            {preview}
+          </p>
+        )
       }
       if (bodyState.kind === 'transient_error') {
         return (


### PR DESCRIPTION
### Description
Following up on closed issue #119 . While the root cause stems from an encoding/formatting quirk in files processed by SpotiFLAC,
With these changes, Astra will successfully detect, parse, and render the lyrics instead of failing silently on these files.

### Changes
- **Backend Parser:** `src/main/services/lyrics.ts` 
  Updated the main lyrics service to robustly catch and parse the unsynced lyric formats.
- **UI Components:** `src/renderer/components/layout/TransportLyricsShelf.tsx` & `src/renderer/components/popout/LyricsPopoutApp.tsx`
  Adjusted the lyric shelf and popout application interfaces to properly handle and display the fallback parsed text.