### PR TITLE
Add artist split exceptions, playlist search, fade/crossfade, and grid customization; fix a few bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,13 +46,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -71,21 +71,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -101,25 +101,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -129,14 +119,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -145,20 +135,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -166,29 +146,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -198,9 +178,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -208,9 +188,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -218,9 +198,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -228,9 +208,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -238,27 +218,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -268,13 +248,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
-      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -284,13 +264,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -300,13 +280,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -316,33 +296,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -350,14 +330,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -400,22 +380,14 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@develar/schema-utils": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
-      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.0",
-        "ajv-keywords": "^3.4.1"
-      },
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/asar": {
@@ -436,26 +408,22 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/@electron/asar/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT"
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@electron/asar/node_modules/minimatch": {
@@ -503,70 +471,48 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
-      }
-    },
-    "node_modules/@electron/get/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@electron/get/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
+        "undici": "^7.24.4"
       }
     },
     "node_modules/@electron/get/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/@electron/get/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -636,9 +582,9 @@
       }
     },
     "node_modules/@electron/rebuild": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
-      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
+      "integrity": "sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -651,19 +597,6 @@
       },
       "bin": {
         "electron-rebuild": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@electron/rebuild/node_modules/node-abi": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
-      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.6.3"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -688,10 +621,17 @@
         "node": ">=16.4"
       }
     },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -699,9 +639,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -752,9 +692,9 @@
       }
     },
     "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1211,18 +1151,18 @@
       }
     },
     "node_modules/@fontsource/inter": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
-      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource/jetbrains-mono": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
-      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -1352,6 +1292,39 @@
         "node": ">=10"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
@@ -1478,6 +1451,19 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@peculiar/utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
@@ -1485,6 +1471,23 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/@peculiar/x509": {
@@ -1516,9 +1519,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
       "cpu": [
         "arm"
       ],
@@ -1530,9 +1533,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
       "cpu": [
         "arm64"
       ],
@@ -1544,9 +1547,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
       "cpu": [
         "arm64"
       ],
@@ -1558,9 +1561,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
       "cpu": [
         "x64"
       ],
@@ -1572,9 +1575,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
       "cpu": [
         "arm64"
       ],
@@ -1586,9 +1589,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
       "cpu": [
         "x64"
       ],
@@ -1600,13 +1603,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1614,13 +1620,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1628,13 +1637,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1642,13 +1654,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1656,13 +1671,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,13 +1688,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1684,13 +1705,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1698,13 +1722,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1712,13 +1739,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,13 +1756,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1740,13 +1773,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1754,13 +1790,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1768,13 +1807,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1782,9 +1824,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
       "cpu": [
         "x64"
       ],
@@ -1796,9 +1838,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
       "cpu": [
         "arm64"
       ],
@@ -1810,9 +1852,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
       "cpu": [
         "arm64"
       ],
@@ -1824,9 +1866,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
       "cpu": [
         "ia32"
       ],
@@ -1838,9 +1880,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
       "cpu": [
         "x64"
       ],
@@ -1852,9 +1894,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
       "cpu": [
         "x64"
       ],
@@ -1993,9 +2035,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2034,31 +2076,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@types/plist": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
-      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*",
-        "xmlbuilder": ">=11.0.1"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2066,9 +2096,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2081,25 +2111,6 @@
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/verror": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
-      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2135,13 +2146,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/7zip-bin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
-      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/abbrev": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
@@ -2163,30 +2167,20 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-regex": {
@@ -2215,40 +2209,36 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/app-builder-bin": {
-      "version": "5.0.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
-      "integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/app-builder-lib": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
-      "integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
+      "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@develar/schema-utils": "~2.6.5",
         "@electron/asar": "3.4.1",
         "@electron/fuses": "^1.8.0",
         "@electron/get": "^3.0.0",
         "@electron/notarize": "2.5.0",
         "@electron/osx-sign": "1.3.3",
-        "@electron/rebuild": "^4.0.3",
+        "@electron/rebuild": "^4.0.4",
         "@electron/universal": "2.0.3",
         "@malept/flatpak-bundler": "^0.4.0",
+        "@noble/hashes": "^2.2.0",
+        "@peculiar/webcrypto": "^1.7.1",
         "@types/fs-extra": "9.0.13",
+        "ajv": "^8.18.0",
+        "asn1js": "^3.0.10",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.8.1",
-        "builder-util-runtime": "9.5.1",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
         "chromium-pickle-js": "^0.2.0",
         "ci-info": "4.3.1",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.8.1",
+        "electron-publish": "26.15.3",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -2256,7 +2246,8 @@
         "js-yaml": "^4.1.0",
         "json5": "^2.2.3",
         "lazy-val": "^1.0.5",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.2.5",
+        "pkijs": "^3.4.0",
         "plist": "3.1.0",
         "proper-lockfile": "^4.1.2",
         "resedit": "^1.7.0",
@@ -2264,14 +2255,15 @@
         "tar": "^7.5.7",
         "temp-file": "^3.4.0",
         "tiny-async-pool": "1.3.0",
+        "unzipper": "^0.12.3",
         "which": "^5.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.8.1",
-        "electron-builder-squirrel-windows": "26.8.1"
+        "dmg-builder": "26.15.3",
+        "electron-builder-squirrel-windows": "26.15.3"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -2337,6 +2329,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/app-builder-lib/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/isexe": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
@@ -2355,6 +2357,19 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/app-builder-lib/node_modules/universalify": {
@@ -2404,28 +2419,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -2461,9 +2454,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "dev": true,
       "funding": [
         {
@@ -2481,8 +2474,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -2497,12 +2490,22 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2525,9 +2528,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.11.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
+      "integrity": "sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2538,9 +2541,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2571,10 +2574,17 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bonjour-service": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
-      "integrity": "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
+      "integrity": "sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2591,20 +2601,22 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2622,10 +2634,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2659,16 +2671,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2676,16 +2678,14 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
-      "integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+      "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
-        "7zip-bin": "~5.2.0",
-        "app-builder-bin": "5.0.0-alpha.12",
-        "builder-util-runtime": "9.5.1",
+        "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.4",
@@ -2698,12 +2698,15 @@
         "stat-mode": "^1.0.0",
         "temp-file": "^3.4.0",
         "tiny-async-pool": "1.3.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2712,6 +2715,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/cac": {
@@ -2768,9 +2781,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2844,24 +2857,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2888,6 +2883,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone-response/node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/color-convert": {
@@ -2966,12 +2971,16 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/convert-source-map": {
@@ -2982,23 +2991,11 @@
       "license": "MIT"
     },
     "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
@@ -3056,18 +3053,6 @@
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3170,6 +3155,24 @@
         "p-limit": "^3.1.0 "
       }
     },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/dir-compare/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3184,47 +3187,16 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.8.1.tgz",
-      "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
+      "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
         "fs-extra": "^10.1.0",
-        "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
-      },
-      "optionalDependencies": {
-        "dmg-license": "^1.0.11"
-      }
-    },
-    "node_modules/dmg-license": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
-      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "@types/plist": "^3.0.1",
-        "@types/verror": "^1.10.3",
-        "ajv": "^6.10.0",
-        "crc": "^3.8.0",
-        "iconv-corefoundation": "^1.1.7",
-        "plist": "^3.0.4",
-        "smart-buffer": "^4.0.2",
-        "verror": "^1.10.0"
-      },
-      "bin": {
-        "dmg-license": "bin/dmg-license.js"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dns-packet": {
@@ -3283,6 +3255,49 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -3300,37 +3315,37 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.10.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.0.tgz",
-      "integrity": "sha512-e7XVcAfyWoFQGS7ZhgxeNn0AijHaqgRCa6uA6TYOrvBWv8smI6JILvMR/8DYBIn07oqvxDLRC90tu/xa2cJCow==",
+      "version": "40.10.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.6.tgz",
+      "integrity": "sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
         "electron": "cli.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.8.1.tgz",
-      "integrity": "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
+      "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
-        "builder-util-runtime": "9.5.1",
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.8.1",
+        "dmg-builder": "26.15.3",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -3345,28 +3360,29 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
-      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
+      "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
         "electron-winstaller": "5.4.0"
       }
     },
     "node_modules/electron-publish": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
-      "integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+      "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "26.8.1",
-        "builder-util-runtime": "9.5.1",
+        "aws4": "^1.13.2",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "form-data": "^4.0.5",
         "fs-extra": "^10.1.0",
@@ -3375,9 +3391,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.355",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
-      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+      "version": "1.5.399",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
+      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3472,14 +3488,21 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "24.10.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
-      "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3498,12 +3521,16 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/err-code": {
@@ -3534,9 +3561,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3652,60 +3679,28 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3751,6 +3746,15 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ffmpeg-static/node_modules/https-proxy-agent": {
@@ -3806,10 +3810,17 @@
         "minimatch": "^5.0.1"
       }
     },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3830,17 +3841,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3994,6 +4005,59 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/global-agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
@@ -4011,6 +4075,20 @@
       },
       "engines": {
         "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/globalthis": {
@@ -4131,9 +4209,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4240,45 +4318,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/iconv-corefoundation": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
-      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "node-addon-api": "^1.6.3"
-      },
-      "engines": {
-        "node": "^8.11.2 || >=10"
-      }
-    },
-    "node_modules/iconv-corefoundation/node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -4333,6 +4372,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
@@ -4372,9 +4418,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4389,10 +4435,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4422,9 +4478,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -4450,9 +4506,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4541,12 +4597,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-2.0.0.tgz",
+      "integrity": "sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mime": {
@@ -4586,52 +4646,31 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -4666,6 +4705,20 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -4692,9 +4745,9 @@
       }
     },
     "node_modules/music-metadata": {
-      "version": "11.12.3",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.12.3.tgz",
-      "integrity": "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.14.0.tgz",
+      "integrity": "sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==",
       "funding": [
         {
           "type": "github",
@@ -4709,11 +4762,11 @@
       "dependencies": {
         "@borewit/text-codec": "^0.2.2",
         "@tokenizer/token": "^0.3.0",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "file-type": "^21.3.1",
-        "media-typer": "^1.1.0",
-        "strtok3": "^10.3.4",
+        "file-type": "^21.3.4",
+        "media-typer": "^2.0.0",
+        "strtok3": "^10.3.5",
         "token-types": "^6.1.2",
         "uint8array-extras": "^1.5.0",
         "win-guid": "^0.2.1"
@@ -4723,9 +4776,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4748,21 +4801,35 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -4778,10 +4845,23 @@
         "semver": "^7.3.5"
       }
     },
+    "node_modules/node-api-version/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-gyp": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
-      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4803,6 +4883,16 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/node-gyp/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/node-gyp/node_modules/isexe": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
@@ -4813,10 +4903,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4839,12 +4942,22 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/node-releases": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "9.0.0",
@@ -4961,13 +5074,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4976,9 +5082,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4986,6 +5092,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/plist": {
@@ -5004,9 +5141,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -5024,7 +5161,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5096,6 +5233,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -5105,6 +5266,13 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -5142,23 +5310,13 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/pvtsutils": {
@@ -5208,24 +5366,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-refresh": {
@@ -5239,9 +5397,9 @@
       }
     },
     "node_modules/react-window": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.2.7.tgz",
-      "integrity": "sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.3.0.tgz",
+      "integrity": "sha512-FW6TIpaOH646k51X7yE+LSCWGkt5Pfsnc1fVyq/sCI9h0pTqmMiBXM04pzFKg3Bt7NGkeV6kqbU8d/QjmFS7Ug==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -5285,6 +5443,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5339,6 +5507,21 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -5359,13 +5542,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -5375,31 +5558,32 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -5423,13 +5607,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/sanitize-filename": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
@@ -5441,9 +5618,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5457,15 +5634,13 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -5581,32 +5756,17 @@
         "node": ">=10"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/source-map": {
@@ -5747,16 +5907,16 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5771,9 +5931,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -5840,72 +6000,6 @@
         "fs-extra": "^10.0.0"
       }
     },
-    "node_modules/temp/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/temp/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/temp/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/temp/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -5933,14 +6027,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5950,9 +6044,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6080,18 +6174,18 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
-      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6103,6 +6197,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "11.3.1",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/unzipper/node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6136,16 +6259,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -6159,30 +6272,14 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/verror": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -6251,9 +6348,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -6268,9 +6365,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -6285,9 +6382,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -6302,9 +6399,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -6319,9 +6416,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -6336,9 +6433,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -6353,9 +6450,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -6370,9 +6467,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -6387,9 +6484,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -6404,9 +6501,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -6421,9 +6518,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -6438,9 +6535,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -6455,9 +6552,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -6472,9 +6569,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -6489,9 +6586,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -6506,9 +6603,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -6523,9 +6620,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -6540,9 +6637,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -6557,9 +6654,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -6574,9 +6671,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -6591,9 +6688,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -6608,9 +6705,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -6625,9 +6722,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -6642,9 +6739,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -6659,9 +6756,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -6676,9 +6773,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -6693,9 +6790,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6706,32 +6803,46 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/which": {
@@ -6808,9 +6919,9 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6836,17 +6947,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -6861,9 +6961,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
-      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -99,7 +99,7 @@ import {
   validateParallaxTlsIdentity,
   type ParallaxTlsIdentity
 } from './services/parallaxSecurity'
-import { LastFmService, sanitizePendingScrobbles } from './services/lastFm'
+import { LastFmService, getArtistInfo as getLastFmArtistInfo, sanitizePendingScrobbles } from './services/lastFm'
 import { LyricsService } from './services/lyrics'
 import { MemoryDiagnosticsService } from './services/memoryDiagnostics'
 import { collectAppMemoryFootprint } from './services/appMemoryFootprint'
@@ -5512,6 +5512,10 @@ ipcMain.handle('lastfm:getStatus', () => {
   return lastFmService.getStatus()
 })
 
+ipcMain.handle('lastfm:getArtistInfo', async (_event, artistName: unknown) => {
+  return getLastFmArtistInfo(typeof artistName === 'string' ? artistName : '', LASTFM_API_KEY)
+})
+
 ipcMain.handle('lastfm:setEnabled', async (_event, enabled: unknown) => {
   const nextConfig: LastFmServiceConfig = {
     ...lastFmConfig,
@@ -7884,6 +7888,18 @@ ipcMain.handle(
     return { success: true, summary }
   }
 )
+
+ipcMain.handle('library:getArtistSplitExceptions', async () => {
+  return library.getArtistSplitExceptions()
+})
+
+ipcMain.handle('library:addArtistSplitException', async (_event, name: string) => {
+  return library.addArtistSplitException(name)
+})
+
+ipcMain.handle('library:removeArtistSplitException', async (_event, name: string) => {
+  return library.removeArtistSplitException(name)
+})
 
 ipcMain.handle(
   'library:rescanFolder',

--- a/src/main/services/lastFm.ts
+++ b/src/main/services/lastFm.ts
@@ -10,6 +10,7 @@ import {
   normalizeLastFmApiBaseUrl,
   parseListenBrainzApiBaseUrl,
   parseLastFmApiBaseUrl,
+  type LastFmArtistInfoResult,
   type LastFmAuthFinishResult,
   type LastFmAuthStartResult,
   type LastFmCustomProfileInput,
@@ -42,6 +43,9 @@ const AUDIOSCROBBLER_PROTOCOL_VERSION = '1.2.1'
 const AUDIOSCROBBLER_CLIENT_ID = 'ast'
 const AUDIOSCROBBLER_CLIENT_VERSION = '0.6.0'
 const LISTENBRAINZ_SUBMIT_PATH = '/1/submit-listens'
+// Filename hash Last.fm serves for artists with no real photo (a gray star
+// placeholder) — treated as "no image" rather than a usable URL.
+const LASTFM_PLACEHOLDER_IMAGE_HASH = '2a96cbd8b46e442fc41c2b86b821562f'
 
 interface LastFmServiceOptions {
   config: LastFmServiceConfig
@@ -431,6 +435,128 @@ export function sanitizePendingScrobbles(raw: unknown): LastFmPendingScrobble[] 
 
   if (deduped.length <= LASTFM_MAX_PENDING_SCROBBLES) return deduped
   return deduped.slice(-LASTFM_MAX_PENDING_SCROBBLES)
+}
+
+function cleanArtistBioSummary(value: unknown): string | null {
+  const summary = normalizeText(value)
+  if (!summary) return null
+  // Last.fm appends a "Read more on Last.fm" link to the end of every summary.
+  const withoutReadMoreLink = summary.replace(/<a\s+href="[^"]*"[^>]*>\s*Read more on Last\.fm\s*<\/a>\.?\s*$/i, '')
+  const withoutTags = withoutReadMoreLink.replace(/<[^>]+>/g, '')
+  const cleaned = normalizeDisplay(withoutTags)
+  return cleaned.length > 0 ? cleaned : null
+}
+
+function extractArtistTags(value: unknown): string[] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return []
+  const rawTag = (value as Record<string, unknown>).tag
+  const tagList = Array.isArray(rawTag) ? rawTag : rawTag ? [rawTag] : []
+
+  const names: string[] = []
+  for (const item of tagList) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue
+    const name = normalizeText((item as Record<string, unknown>).name)
+    if (name) names.push(name)
+  }
+  return names
+}
+
+function extractArtistImageUrl(value: unknown): string | null {
+  if (!Array.isArray(value)) return null
+
+  const bySize = new Map<string, string>()
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue
+    const record = item as Record<string, unknown>
+    const src = normalizeText(record['#text'])
+    if (!src || src.includes(LASTFM_PLACEHOLDER_IMAGE_HASH)) continue
+    const size = normalizeText(record.size) ?? ''
+    bySize.set(size, src)
+  }
+
+  return bySize.get('mega') ?? bySize.get('extralarge') ?? bySize.get('large') ?? null
+}
+
+// Public, unsigned lookup (no session/api_sig needed) — always targets the
+// official Last.fm API regardless of which scrobble profile is active.
+export async function getArtistInfo(artistName: string, apiKey: string): Promise<LastFmArtistInfoResult> {
+  const normalizedArtistName = normalizeText(artistName)
+  if (!normalizedArtistName) {
+    return { ok: false, message: 'Artist name is required.' }
+  }
+
+  const trimmedApiKey = apiKey.trim()
+  if (!trimmedApiKey) {
+    return { ok: false, message: 'Last.fm credentials are not configured for this build.' }
+  }
+
+  const url = new URL(LASTFM_OFFICIAL_API_BASE_URL)
+  url.searchParams.set('method', 'artist.getInfo')
+  url.searchParams.set('api_key', trimmedApiKey)
+  url.searchParams.set('artist', normalizedArtistName)
+  url.searchParams.set('format', 'json')
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), LASTFM_REQUEST_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': LASTFM_USER_AGENT
+      },
+      signal: controller.signal
+    })
+
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch {
+      payload = null
+    }
+
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return { ok: false, message: `Last.fm request failed with HTTP ${response.status}.` }
+    }
+
+    const record = payload as Record<string, unknown>
+    const errorCode = toApiErrorCode(record.error)
+    if (errorCode != null) {
+      const errorMessage = normalizeText(record.message)
+      return { ok: false, message: formatApiErrorMessage(errorCode, errorMessage ?? 'Artist not found.') }
+    }
+
+    const artistValue = record.artist
+    if (!artistValue || typeof artistValue !== 'object' || Array.isArray(artistValue)) {
+      return { ok: false, message: 'Last.fm returned an invalid artist payload.' }
+    }
+    const artistRecord = artistValue as Record<string, unknown>
+
+    return {
+      ok: true,
+      artist: {
+        name: normalizeText(artistRecord.name) ?? normalizedArtistName,
+        bio: cleanArtistBioSummary(
+          artistRecord.bio && typeof artistRecord.bio === 'object' && !Array.isArray(artistRecord.bio)
+            ? (artistRecord.bio as Record<string, unknown>).summary
+            : null
+        ),
+        tags: extractArtistTags(artistRecord.tags ?? artistRecord.toptags),
+        imageUrl: extractArtistImageUrl(artistRecord.image)
+      }
+    }
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === 'AbortError'
+    return {
+      ok: false,
+      message: isAbort
+        ? 'Last.fm artist lookup timed out.'
+        : 'Last.fm artist lookup failed due to a network error.'
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
 }
 
 export class LastFmService {

--- a/src/main/services/library.ts
+++ b/src/main/services/library.ts
@@ -202,6 +202,7 @@ export interface DbTrack {
   track_number: number | null
   disc_number: number | null
   year: number | null
+  date: string | null
   genre: string | null
   genres: string[]
   artwork_hash: string | null
@@ -695,6 +696,7 @@ class LibrarySqliteDatabase {
 
 let db: LibrarySqliteDatabase | null = null
 let dbPath: string = ''
+let artistSplitExceptionKeys: Set<string> = new Set()
 let artworkDir: string = ''
 let playlistCoverDir: string = ''
 let artistImageDir: string = ''
@@ -731,6 +733,7 @@ const EFFECTIVE_TRACK_SELECT_COLUMNS = `
   COALESCE(o.track_number, t.track_number) AS track_number,
   COALESCE(o.disc_number, t.disc_number) AS disc_number,
   COALESCE(o.year, t.year) AS year,
+  t.date AS date,
   COALESCE(o.genre, t.genre) AS genre,
   CASE
     WHEN o.genre IS NULL THEN t.genre_names_json
@@ -1206,7 +1209,7 @@ function deserializeGenreNames(value: unknown): string[] {
 }
 
 function formatGenreNames(names: readonly unknown[] | null | undefined): string {
-  return normalizeGenreNames(names).join('; ')
+  return normalizeGenreNames(names).join(', ')
 }
 
 function getGenreNamesForTrack(track: Pick<DbTrackRow, 'genre' | 'genre_names_json'>): string[] {
@@ -1374,6 +1377,10 @@ function splitCollaborators(rawArtist: string): string[] {
   const normalized = normalizeDisplay(rawArtist)
   if (!normalized) return []
 
+  if (artistSplitExceptionKeys.has(normalizeKey(normalized))) {
+    return [normalized]
+  }
+
   const unified = normalized
     .replace(/\s*;\s*/g, ',')
     .replace(/\s+&\s+/g, ',')
@@ -1395,6 +1402,10 @@ function splitCollaborators(rawArtist: string): string[] {
 function splitAlbumArtistCollaborators(rawAlbumArtist: string): string[] {
   const normalized = normalizeDisplay(rawAlbumArtist)
   if (!normalized) return []
+
+  if (artistSplitExceptionKeys.has(normalizeKey(normalized))) {
+    return [normalized]
+  }
 
   const unified = normalized
     .replace(/\s*;\s*/g, ',')
@@ -2229,6 +2240,11 @@ export async function initDatabase(): Promise<void> {
     // Column already exists.
   }
   try {
+    db.run('ALTER TABLE tracks ADD COLUMN date TEXT')
+  } catch {
+    // Column already exists.
+  }
+  try {
     db.run('ALTER TABLE track_metadata_overrides ADD COLUMN artwork_hash TEXT')
   } catch {
     // Column already exists.
@@ -2274,6 +2290,16 @@ export async function initDatabase(): Promise<void> {
   `)
   db.run('CREATE INDEX IF NOT EXISTS idx_folder_exclusions_folder ON folder_exclusions(folder_id)')
   db.run('CREATE INDEX IF NOT EXISTS idx_folder_exclusions_absolute ON folder_exclusions(absolute_path)')
+
+  // Artist split exceptions: full artist-credit strings that splitCollaborators
+  // must never break apart (e.g. "Tyler, The Creator", "Earth, Wind & Fire").
+  db.run(`
+    CREATE TABLE IF NOT EXISTS artist_split_exceptions (
+      artist_key TEXT PRIMARY KEY NOT NULL,
+      artist_name TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `)
 
   db.run('CREATE INDEX IF NOT EXISTS idx_tracks_artist ON tracks(artist)')
   db.run('CREATE INDEX IF NOT EXISTS idx_tracks_album ON tracks(album)')
@@ -2461,6 +2487,7 @@ export async function initDatabase(): Promise<void> {
       artist_name TEXT NOT NULL,
       manual_image_hash TEXT,
       detected_image_hash TEXT,
+      remote_image_hash TEXT,
       detected_source_path TEXT,
       detected_source_mtime INTEGER,
       updated_at INTEGER NOT NULL,
@@ -2468,6 +2495,14 @@ export async function initDatabase(): Promise<void> {
     )
   `)
   db.run('CREATE INDEX IF NOT EXISTS idx_artist_images_browse_mode ON artist_images(browse_mode)')
+
+  // Schema migration: existing artist_images rows may not have remote_image_hash yet.
+  // Checked via table_info rather than the usual try/catch ALTER pattern so this
+  // stays a plain no-op (no thrown-and-caught exception) on repeat startups.
+  const artistImagesColumns = db.pragma('table_info(artist_images)') as Array<{ name: string }>
+  if (!artistImagesColumns.some((column) => column.name === 'remote_image_hash')) {
+    db.run('ALTER TABLE artist_images ADD COLUMN remote_image_hash TEXT')
+  }
 
   // Playlist tracks table
   db.run(`
@@ -2553,6 +2588,8 @@ export async function initDatabase(): Promise<void> {
   // Upgrade-time repair for histories and path-keyed user data orphaned by a
   // folder reorganization in an older Astra version.
   reconcileMissingTrackReferencesByMetadata()
+
+  refreshArtistSplitExceptionCache()
 
   await saveDatabase()
 }
@@ -4910,19 +4947,12 @@ function normalizeCachedImageExtension(imagePath: string): string {
   return '.jpg'
 }
 
-async function cacheArtistImageFile(imagePath: string): Promise<string> {
-  const normalizedPath = imagePath.trim()
-  if (!normalizedPath) {
-    throw new Error('Artist image path is required.')
-  }
-
-  const imageData = await readFile(normalizedPath)
+async function writeCachedArtistImageBuffer(imageData: Buffer, extension: string): Promise<string> {
   if (imageData.length === 0) {
-    throw new Error('Artist image file is empty.')
+    throw new Error('Artist image data is empty.')
   }
 
   await mkdir(artistImageDir, { recursive: true })
-  const extension = normalizeCachedImageExtension(normalizedPath)
   const contentHash = createHash('sha256').update(imageData).digest('hex')
   const fileName = `${contentHash}${extension}`
   const targetPath = join(artistImageDir, fileName)
@@ -4936,6 +4966,17 @@ async function cacheArtistImageFile(imagePath: string): Promise<string> {
   }
 
   return `${ARTIST_IMAGE_HASH_PREFIX}${fileName}`
+}
+
+async function cacheArtistImageFile(imagePath: string): Promise<string> {
+  const normalizedPath = imagePath.trim()
+  if (!normalizedPath) {
+    throw new Error('Artist image path is required.')
+  }
+
+  const imageData = await readFile(normalizedPath)
+  const extension = normalizeCachedImageExtension(normalizedPath)
+  return writeCachedArtistImageBuffer(imageData, extension)
 }
 
 export async function setArtistImageFromFile(
@@ -5219,6 +5260,10 @@ export function getArtists(mode: ArtistBrowseMode = 'canonical'): ArtistRecord[]
         })
       }
 
+      // Only an artist's own releases should set their page artwork — a track
+      // where this artist is merely featured (not primary) must not be able
+      // to override the primary artist's cover with someone else's album art.
+      if (!isPrimaryArtist) return
       if (!track.artwork_hash) return
       const aggregate = artistCounts.get(key)
       if (!aggregate) return
@@ -5977,6 +6022,51 @@ export async function setFolderSubfolderExcluded(
   return true
 }
 
+interface ArtistSplitExceptionRow {
+  artist_name: string
+}
+
+export function getArtistSplitExceptions(): string[] {
+  if (!db) return []
+  const rows = db.all<ArtistSplitExceptionRow>('SELECT artist_name FROM artist_split_exceptions ORDER BY artist_name')
+  return rows.map((row) => row.artist_name)
+}
+
+function refreshArtistSplitExceptionCache(): void {
+  artistSplitExceptionKeys = new Set(getArtistSplitExceptions().map((name) => normalizeKey(name)))
+}
+
+export async function addArtistSplitException(name: string): Promise<boolean> {
+  if (!db) return false
+  const displayName = normalizeDisplay(name)
+  const key = normalizeKey(displayName)
+  if (!key) return false
+
+  db.run(
+    `INSERT INTO artist_split_exceptions (artist_key, artist_name, created_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(artist_key)
+     DO UPDATE SET artist_name = excluded.artist_name`,
+    [key, displayName, Date.now()]
+  )
+
+  await saveDatabase()
+  refreshArtistSplitExceptionCache()
+  return true
+}
+
+export async function removeArtistSplitException(name: string): Promise<boolean> {
+  if (!db) return false
+  const key = normalizeKey(name)
+  if (!key) return false
+
+  db.run('DELETE FROM artist_split_exceptions WHERE artist_key = ?', [key])
+
+  await saveDatabase()
+  refreshArtistSplitExceptionCache()
+  return true
+}
+
 // Remove library folder
 export async function removeLibraryFolder(folderPath: string): Promise<void> {
   if (!db) return
@@ -6338,11 +6428,11 @@ export async function scanFolder(
 
       if (existing) {
         db.run(`
-          UPDATE tracks SET title=?, artist=?, artist_names_json=?, album=?, album_artist=?, album_artist_names_json=?, duration=?, track_number=?, disc_number=?, year=?, genre=?, genre_names_json=?, artwork_hash=?, format=?, sample_rate=?, bit_depth=?, bitrate=?, channels=?, codec=?, codec_profile=?, is_atmos_joc=?, is_iamf=?, replaygain_track_gain_db=?, replaygain_album_gain_db=?, bpm=?, musical_key=?, source_type='local', source_id=NULL, source_track_id=NULL, source_path=NULL, is_available=1, availability_reason=NULL, file_created_at=?, modified_at=?
+          UPDATE tracks SET title=?, artist=?, artist_names_json=?, album=?, album_artist=?, album_artist_names_json=?, duration=?, track_number=?, disc_number=?, year=?, date=?, genre=?, genre_names_json=?, artwork_hash=?, format=?, sample_rate=?, bit_depth=?, bitrate=?, channels=?, codec=?, codec_profile=?, is_atmos_joc=?, is_iamf=?, replaygain_track_gain_db=?, replaygain_album_gain_db=?, bpm=?, musical_key=?, source_type='local', source_id=NULL, source_track_id=NULL, source_path=NULL, is_available=1, availability_reason=NULL, file_created_at=?, modified_at=?
           WHERE path=?
         `, [
           metadata.title, metadata.artist, metadata.artistNamesJson, metadata.album, metadata.albumArtist, metadata.albumArtistNamesJson,
-          metadata.duration, metadata.trackNumber, metadata.discNumber, metadata.year,
+          metadata.duration, metadata.trackNumber, metadata.discNumber, metadata.year, metadata.date,
           metadata.genre, metadata.genreNamesJson, metadata.artworkHash, metadata.format, metadata.sampleRate,
           metadata.bitDepth, metadata.bitrate, metadata.channels, metadata.codec, metadata.codecProfile, metadata.isAtmosJoc, metadata.isIamf,
           metadata.replayGainTrackDb, metadata.replayGainAlbumDb, metadata.bpm, metadata.musicalKey, fileCreatedAt, now, filePath
@@ -6350,11 +6440,11 @@ export async function scanFolder(
         updated++
       } else {
         db.run(`
-          INSERT INTO tracks (path, title, artist, artist_names_json, album, album_artist, album_artist_names_json, duration, track_number, disc_number, year, genre, genre_names_json, artwork_hash, format, sample_rate, bit_depth, bitrate, channels, codec, codec_profile, is_atmos_joc, is_iamf, replaygain_track_gain_db, replaygain_album_gain_db, bpm, musical_key, source_type, source_id, source_track_id, source_path, is_available, availability_reason, file_created_at, sync_session_key, added_at, modified_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'local', NULL, NULL, NULL, 1, NULL, ?, ?, ?, ?)
+          INSERT INTO tracks (path, title, artist, artist_names_json, album, album_artist, album_artist_names_json, duration, track_number, disc_number, year, date, genre, genre_names_json, artwork_hash, format, sample_rate, bit_depth, bitrate, channels, codec, codec_profile, is_atmos_joc, is_iamf, replaygain_track_gain_db, replaygain_album_gain_db, bpm, musical_key, source_type, source_id, source_track_id, source_path, is_available, availability_reason, file_created_at, sync_session_key, added_at, modified_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'local', NULL, NULL, NULL, 1, NULL, ?, ?, ?, ?)
         `, [
           filePath, metadata.title, metadata.artist, metadata.artistNamesJson, metadata.album, metadata.albumArtist, metadata.albumArtistNamesJson,
-          metadata.duration, metadata.trackNumber, metadata.discNumber, metadata.year,
+          metadata.duration, metadata.trackNumber, metadata.discNumber, metadata.year, metadata.date,
           metadata.genre, metadata.genreNamesJson, metadata.artworkHash, metadata.format, metadata.sampleRate,
           metadata.bitDepth, metadata.bitrate, metadata.channels, metadata.codec, metadata.codecProfile, metadata.isAtmosJoc, metadata.isIamf,
           metadata.replayGainTrackDb, metadata.replayGainAlbumDb, metadata.bpm, metadata.musicalKey, fileCreatedAt, syncSessionKey, now, now
@@ -6971,6 +7061,7 @@ interface ExtractedTrackMetadata {
   trackNumber: number | null
   discNumber: number | null
   year: number | null
+  date: string | null
   genre: string | null
   genreNamesJson: string | null
   artworkHash: string | null
@@ -7062,6 +7153,7 @@ async function buildIamfTrackMetadata(
     trackNumber: null,
     discNumber: null,
     year: null,
+    date: null,
     genre: null,
     genreNamesJson: null,
     artworkHash,
@@ -7193,6 +7285,7 @@ async function extractMetadata(filePath: string, options: {
       trackNumber: common.track?.no || null,
       discNumber: common.disk?.no || null,
       year: common.year || null,
+      date: common.date || null,
       genre: genreFields.genre,
       genreNamesJson: genreFields.genreNamesJson,
       artworkHash,
@@ -7925,11 +8018,11 @@ async function updateTrackRowFromFileMetadata(trackPath: string): Promise<void> 
   const now = Date.now()
 
   db.run(`
-    UPDATE tracks SET title=?, artist=?, artist_names_json=?, album=?, album_artist=?, album_artist_names_json=?, duration=?, track_number=?, disc_number=?, year=?, genre=?, genre_names_json=?, artwork_hash=?, format=?, sample_rate=?, bit_depth=?, bitrate=?, channels=?, codec=?, codec_profile=?, is_atmos_joc=?, is_iamf=?, replaygain_track_gain_db=?, replaygain_album_gain_db=?, bpm=?, musical_key=?, source_type='local', source_id=NULL, source_track_id=NULL, source_path=NULL, is_available=1, availability_reason=NULL, file_created_at=?, modified_at=?
+    UPDATE tracks SET title=?, artist=?, artist_names_json=?, album=?, album_artist=?, album_artist_names_json=?, duration=?, track_number=?, disc_number=?, year=?, date=?, genre=?, genre_names_json=?, artwork_hash=?, format=?, sample_rate=?, bit_depth=?, bitrate=?, channels=?, codec=?, codec_profile=?, is_atmos_joc=?, is_iamf=?, replaygain_track_gain_db=?, replaygain_album_gain_db=?, bpm=?, musical_key=?, source_type='local', source_id=NULL, source_track_id=NULL, source_path=NULL, is_available=1, availability_reason=NULL, file_created_at=?, modified_at=?
     WHERE path=?
   `, [
     metadata.title, metadata.artist, metadata.artistNamesJson, metadata.album, metadata.albumArtist, metadata.albumArtistNamesJson,
-    metadata.duration, metadata.trackNumber, metadata.discNumber, metadata.year,
+    metadata.duration, metadata.trackNumber, metadata.discNumber, metadata.year, metadata.date,
     metadata.genre, metadata.genreNamesJson, metadata.artworkHash, metadata.format, metadata.sampleRate,
     metadata.bitDepth, metadata.bitrate, metadata.channels, metadata.codec, metadata.codecProfile, metadata.isAtmosJoc, metadata.isIamf,
     metadata.replayGainTrackDb, metadata.replayGainAlbumDb, metadata.bpm, metadata.musicalKey, fileCreatedAt, now, trackPath

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -56,6 +56,7 @@ import type {
 import type { TrackRatingEntry } from '../shared/ratings/trackRating'
 import type { AppMemoryFootprintSource } from '../shared/processMemoryFootprint'
 import type {
+  LastFmArtistInfoResult,
   LastFmAuthFinishResult,
   LastFmAuthStartResult,
   LastFmCustomProfileInput,
@@ -230,6 +231,7 @@ export interface DbTrack {
   track_number: number | null
   disc_number: number | null
   year: number | null
+  date: string | null
   genre: string | null
   genres: string[]
   artwork_hash: string | null
@@ -1088,6 +1090,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   lastFm: {
     getStatus: (): Promise<LastFmStatus> => ipcRenderer.invoke('lastfm:getStatus'),
+    getArtistInfo: (artistName: string): Promise<LastFmArtistInfoResult> =>
+      ipcRenderer.invoke('lastfm:getArtistInfo', artistName),
     setEnabled: (enabled: boolean): Promise<LastFmStatus> => ipcRenderer.invoke('lastfm:setEnabled', enabled),
     createCustomProfile: (input: LastFmCustomProfileInput): Promise<LastFmStatus> =>
       ipcRenderer.invoke('lastfm:createCustomProfile', input),
@@ -1320,6 +1324,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
         summary?: FolderSubfolderSummary
         error?: string
       }>,
+    getArtistSplitExceptions: () => ipcRenderer.invoke('library:getArtistSplitExceptions') as Promise<string[]>,
+    addArtistSplitException: (name: string) => ipcRenderer.invoke('library:addArtistSplitException', name) as Promise<boolean>,
+    removeArtistSplitException: (name: string) => ipcRenderer.invoke('library:removeArtistSplitException', name) as Promise<boolean>,
     rescanFolder: (folderPath: string) => ipcRenderer.invoke('library:rescanFolder', folderPath) as Promise<{
       success: boolean
       canceled?: boolean
@@ -1758,6 +1765,7 @@ declare global {
       }
       lastFm: {
         getStatus: () => Promise<LastFmStatus>
+        getArtistInfo: (artistName: string) => Promise<LastFmArtistInfoResult>
         setEnabled: (enabled: boolean) => Promise<LastFmStatus>
         createCustomProfile: (input: LastFmCustomProfileInput) => Promise<LastFmStatus>
         updateCustomProfile: (profileId: string, input: LastFmCustomProfileInput) => Promise<LastFmStatus>
@@ -1894,6 +1902,9 @@ declare global {
           summary?: FolderSubfolderSummary
           error?: string
         }>
+        getArtistSplitExceptions: () => Promise<string[]>
+        addArtistSplitException: (name: string) => Promise<boolean>
+        removeArtistSplitException: (name: string) => Promise<boolean>
         rescanFolder: (folderPath: string) => Promise<{
           success: boolean
           canceled?: boolean

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -30,7 +30,7 @@ import MetadataEditorPanel from './components/metadata/MetadataEditorPanel'
 import LyricsEditorPanel from './components/lyrics/LyricsEditorPanel'
 import SignalShareModal from './components/signal/SignalShareModal'
 import { useUIStore } from './stores/uiStore'
-import { useLibraryStore } from './stores/libraryStore'
+import { ARTIST_SPLIT_EXCEPTIONS_PENDING_RESTART_STORAGE_KEY, useLibraryStore } from './stores/libraryStore'
 import { useRatingsStore } from './stores/ratingsStore'
 import { useAudioSettingsStore } from './stores/audioSettingsStore'
 import { useDiscordSettingsStore } from './stores/discordSettingsStore'
@@ -370,6 +370,10 @@ function App() {
         const libraryStore = useLibraryStore.getState()
         void useRatingsStore.getState().loadRatings()
         await libraryStore.loadLibrary()
+        if (localStorage.getItem(ARTIST_SPLIT_EXCEPTIONS_PENDING_RESTART_STORAGE_KEY) === '1') {
+          libraryStore.setArtistSplitExceptionsRestartConfirmation('✓ Artist exceptions have been applied')
+          localStorage.setItem(ARTIST_SPLIT_EXCEPTIONS_PENDING_RESTART_STORAGE_KEY, '0')
+        }
         if (sessionSnapshot?.library) {
           await libraryStore.restoreSession(sessionSnapshot.library)
         }

--- a/src/renderer/audio/AudioEngine.ts
+++ b/src/renderer/audio/AudioEngine.ts
@@ -89,6 +89,15 @@ const FADE_STOP_EPSILON_MS = 20
 // track immediately: the outgoing source is stopped at the bottom of the dip so its mid-sample
 // cutoff lands in silence (no click), while the incoming source's onset rides the dip back up.
 const SKIP_DECLICK_MS = 12
+// Below this much remaining playback, scheduleFadeOutForQueueEnd skips arming a ramp entirely —
+// too little runway left for a fade to be worth anything, and scheduling one anyway risks a
+// same-instant setValueAtTime(1)/linearRampToValueAtTime(0) pair that cuts straight to silence.
+const FADE_OUT_MIN_REMAINING_SEC = 0.1
+// Short resync ramp used to bring fadeGainNode back to full volume before a remote/progressive
+// stream starts producing audio — that path doesn't go through play()'s standard cold-start block,
+// which already re-arms this shared node, so it can otherwise still be sitting near 0 from a
+// previous track's pause fade.
+const REMOTE_STREAM_FADE_RESYNC_MS = 40
 
 const NORMALIZATION_MIN_GAIN_DB = -18
 const NORMALIZATION_MAX_GAIN_DB = 6
@@ -198,6 +207,14 @@ export interface ExternalLoudnessResult {
 export interface AudioLoadTimings {
   decodeMs: number
   analysisMs: number
+}
+
+export interface FadeSettings {
+  fadeEnabled: boolean
+  fadeInDurationMs: number
+  fadeOutDurationMs: number
+  crossfadeEnabled: boolean
+  crossfadeDurationMs: number
 }
 
 interface AudioLoadDataOptions {
@@ -340,6 +357,9 @@ interface CalibrationToneSignal {
 export class AudioEngine {
   private context: AudioContext | null = null
   private sourceNode: AudioBufferSourceNode | null = null
+  // Per-source gain, dedicated to this particular AudioBufferSourceNode instance (recreated
+  // alongside it). Carries the fade-in/queue-end-fade-out envelope; crossfade reuses it too.
+  private sourceGainNode: GainNode | null = null
   private gainNode: GainNode | null = null
   // Final-stage gain used only for play/pause/skip fades, independent of volume/mute and normalization.
   private fadeGainNode: GainNode | null = null
@@ -422,8 +442,30 @@ export class AudioEngine {
   // Gapless playback support
   private nextBuffer: AudioBuffer | null = null
   private nextSourceNode: AudioBufferSourceNode | null = null
+  // Mirrors sourceGainNode for the pre-scheduled next source.
+  private nextSourceGainNode: GainNode | null = null
   private scheduledEndTime: number = 0
   private isGaplessTransition: boolean = false
+
+  // Fade-in/out and crossfade preferences (audioSettingsStore is the source of truth).
+  private fadeSettings: FadeSettings = {
+    fadeEnabled: false,
+    fadeInDurationMs: 2000,
+    fadeOutDurationMs: 2000,
+    crossfadeEnabled: false,
+    crossfadeDurationMs: 3000,
+  }
+  // AudioContext time the current queue-end fade-out's plateau-anchor was scheduled at, so a
+  // later-arriving next track can surgically cancel just that automation (see
+  // cancelQueueEndFadeOut). Null when no queue-end fade-out is currently armed.
+  private queueEndFadeOutRampStartTime: number | null = null
+  // Deferred teardown for stop()'s fade-out, mirroring pauseFadeTimer's pattern.
+  private fadeOutStopTimer: ReturnType<typeof setTimeout> | null = null
+  // AudioContext time the current crossfade's plateau-anchor was scheduled at on sourceGainNode.
+  // scheduleGaplessTransition can re-run against the same still-playing source (e.g. a rapid
+  // pause/resume with a next track already queued) — this lets it surgically cancel a stale
+  // crossfade ramp before arming a fresh one, instead of stacking automation events.
+  private crossfadeRampStartTime: number | null = null
 
   private animationFrame: number | null = null
   private eventListeners: Map<string, Set<EventCallback>> = new Map()
@@ -538,6 +580,19 @@ export class AudioEngine {
 
   isBitPerfectRouteActive(): boolean {
     return this.isBitPerfectActive()
+  }
+
+  // Fade-in/out and crossfade mix samples on a per-source GainNode, which bit-perfect (exclusive/
+  // direct device output, no app DSP) structurally cannot support. Checked at the point of use, in
+  // addition to the UI already disabling those controls while bit-perfect is active.
+  private isFadeCrossfadeAllowed(): boolean {
+    return this.playbackOutputMode !== 'bitperfect'
+  }
+
+  // Crossfade (two simultaneous sources) lands in a later step; fadeEnabled/fadeIn/fadeOut are
+  // already live via the per-source GainNode.
+  setFadeSettings(settings: FadeSettings): void {
+    this.fadeSettings = { ...settings }
   }
 
   getPlaybackModeStatusMessage(): string | null {
@@ -1357,9 +1412,9 @@ export class AudioEngine {
 
     this.stopSource()
     this.cancelScheduledNext()
-    this.sourceNode = ctx.createBufferSource()
-    this.sourceNode.buffer = buffer
-    this.connectSourceWithRouting(this.sourceNode, buffer.numberOfChannels)
+    this.sourceNode = this.createTrackSourceNode(buffer)
+    this.sourceGainNode = this.createTrackSourceGainNode(this.sourceNode)
+    this.connectSourceWithRouting(this.sourceGainNode, buffer.numberOfChannels)
     this.connectSourceToAnalysisTap(this.sourceNode, buffer.numberOfChannels)
     this.sourceNode.onended = () => {
       if (this._playbackState === 'playing') this.performGaplessTransition()
@@ -1673,6 +1728,21 @@ export class AudioEngine {
     for (const node of nodes) {
       this.applyNodeRoutingMode(node, analysisChannels, mode, interpretation)
     }
+  }
+
+  private createTrackSourceNode(buffer: AudioBuffer): AudioBufferSourceNode {
+    const newSource = this.context!.createBufferSource()
+    newSource.buffer = buffer
+    return newSource
+  }
+
+  // Dedicated per-source gain, connected between the source and the shared routing chain.
+  // Always unity today; this is the insertion point for future fade-in/out and crossfade ramps.
+  private createTrackSourceGainNode(source: AudioBufferSourceNode): GainNode {
+    const gain = this.context!.createGain()
+    gain.gain.value = 1
+    source.connect(gain)
+    return gain
   }
 
   private connectSourceWithRouting(sourceNode: AudioNode, sourceChannels: number): void {
@@ -2428,15 +2498,41 @@ export class AudioEngine {
   private maybeStartRemotePlayback(): void {
     const remoteState = this.remoteStreamState
     if (!remoteState || !this.remoteStreamNode) return
-    if (!remoteState.playRequested || remoteState.started) return
 
     const playableFrames = Math.floor(remoteState.sampleRate * REMOTE_STREAM_PLAYABLE_SECONDS)
     const hasEnoughBuffered = remoteState.bufferedFrames >= playableFrames
       || (remoteState.sourceEnded && remoteState.bufferedFrames > 0)
+    console.log('[DEBUG] maybeStartRemotePlayback', {
+      bufferedFrames: remoteState.bufferedFrames,
+      playableFrames,
+      hasEnoughBuffered,
+      started: remoteState.started,
+      playRequested: remoteState.playRequested
+    })
+
+    if (!remoteState.playRequested || remoteState.started) return
     if (!hasEnoughBuffered) return
 
     remoteState.started = true
     remoteState.paused = false
+    const routingSink = this.getRoutingSinkNode()
+    const routingSinkLabel = routingSink === null
+      ? 'null'
+      : routingSink === this.spatialWorkletNode
+        ? 'spatialWorkletNode'
+        : routingSink === this.normalizationGainNode
+          ? 'normalizationGainNode'
+          : 'other'
+    console.log('[DEBUG] maybeStartRemotePlayback: gain chain before set-playing', {
+      fadeGainNodeValue: this.fadeGainNode?.gain.value ?? null,
+      gainNodeValue: this.gainNode?.gain.value ?? null,
+      normalizationGainNodeValue: this.normalizationGainNode?.gain.value ?? null,
+      preampNodeValue: this.preampNode?.gain.value ?? null,
+      isMuted: this._isMuted,
+      isBinauralActive: this.isBinauralActive(),
+      routingSink: routingSinkLabel
+    })
+    this.resyncFadeGainNodeToFull()
     this.remoteStreamNode.port.postMessage({
       type: 'set-playing',
       playing: true
@@ -2488,6 +2584,13 @@ export class AudioEngine {
 
   private handleRemoteStreamChunk(chunk: RemoteStreamChunk): void {
     const remoteState = this.remoteStreamState
+    console.log('[DEBUG] handleRemoteStreamChunk', {
+      chunkSessionId: chunk.sessionId,
+      currentRemoteStateSessionId: remoteState?.sessionId ?? null,
+      remoteStateExists: Boolean(remoteState),
+      remoteStreamNodeExists: Boolean(this.remoteStreamNode),
+      willBeDropped: !remoteState || chunk.sessionId !== remoteState.sessionId || !this.remoteStreamNode
+    })
     if (!remoteState || chunk.sessionId !== remoteState.sessionId || !this.remoteStreamNode) {
       return
     }
@@ -2671,6 +2774,11 @@ export class AudioEngine {
         ? null
         : this.createProgressiveNormalizationAccumulator(info.sampleRate)
     }
+    console.log('[DEBUG] loadProgressiveStream: this.remoteStreamState assigned', {
+      sessionId: this.remoteStreamState.sessionId,
+      trackPath: this.remoteStreamState.path,
+      atTime: performance.now()
+    })
 
     this.applyChannelRoutingPreferences(info.channels)
     this.applyAnalysisRoutingPreferences(info.channels)
@@ -2708,6 +2816,11 @@ export class AudioEngine {
     }
 
     this.assertCurrentLoadOperation(loadOperation)
+    console.log('[DEBUG] loadProgressiveStream: returning', {
+      sessionId: info.sessionId,
+      trackPath: track.path,
+      atTime: performance.now()
+    })
     return info
   }
 
@@ -3161,9 +3274,9 @@ export class AudioEngine {
     })
     const startAtContextTime = Math.max(this.context.currentTime, mappedStartContextTime)
 
-    this.sourceNode = this.context.createBufferSource()
-    this.sourceNode.buffer = this.audioBuffer
-    this.connectSourceWithRouting(this.sourceNode, this.audioBuffer.numberOfChannels)
+    this.sourceNode = this.createTrackSourceNode(this.audioBuffer)
+    this.sourceGainNode = this.createTrackSourceGainNode(this.sourceNode)
+    this.connectSourceWithRouting(this.sourceGainNode, this.audioBuffer.numberOfChannels)
     this.connectSourceToAnalysisTap(this.sourceNode, this.audioBuffer.numberOfChannels)
     this.sourceNode.onended = () => {
       if (this._playbackState === 'playing') {
@@ -6327,11 +6440,17 @@ export class AudioEngine {
     if (!this.context || !this.nextBuffer || !this.audioBuffer) return
     if (this._playbackState !== 'playing') return
 
+    // A next track showed up after all — undo any queue-end fade-out armed for this source.
+    this.cancelQueueEndFadeOut()
+
     if (this.nextNormalizationLinearGain == null) {
       this.updateNextNormalizationCache()
     }
 
-    // Cancel any existing scheduled next source
+    // Cancel any existing scheduled next source. This also surgically undoes a crossfade ramp
+    // that a previous call may have armed on this still-playing source (e.g. a rapid
+    // pause/resume with a next track already queued), so a fresh one can be computed below
+    // without stacking automation events.
     this.cancelScheduledNext()
 
     // Calculate when current track will end
@@ -6339,16 +6458,39 @@ export class AudioEngine {
     const remaining = this.audioBuffer.duration - currentPosition
     this.scheduledEndTime = this.context.currentTime + remaining
 
+    const crossfadeActive = (
+      this.isFadeCrossfadeAllowed() &&
+      this.fadeSettings.crossfadeEnabled &&
+      this.fadeSettings.crossfadeDurationMs > 0
+    )
+    // Cap the overlap to what's actually left, so nextStartTime never lands in the past.
+    const crossfadeSec = crossfadeActive
+      ? Math.min(this.fadeSettings.crossfadeDurationMs / 1000, Math.max(0, remaining))
+      : 0
+    const nextStartTime = this.scheduledEndTime - crossfadeSec
+
     // Create and schedule the next source
-    this.nextSourceNode = this.context.createBufferSource()
-    this.nextSourceNode.buffer = this.nextBuffer
-    this.connectSourceWithRouting(this.nextSourceNode, this.nextBuffer.numberOfChannels)
+    this.nextSourceNode = this.createTrackSourceNode(this.nextBuffer)
+    this.nextSourceGainNode = this.createTrackSourceGainNode(this.nextSourceNode)
+    this.connectSourceWithRouting(this.nextSourceGainNode, this.nextBuffer.numberOfChannels)
     this.connectSourceToAnalysisTap(this.nextSourceNode, this.nextBuffer.numberOfChannels)
 
-    // Schedule to start exactly when current track ends
-    this.nextSourceNode.start(this.scheduledEndTime)
+    // Schedule to start exactly when current track ends — or crossfadeSec earlier, so the two
+    // sources overlap instead of cutting.
+    this.nextSourceNode.start(nextStartTime)
     if (this.nextNormalizationLinearGain != null) {
       this.scheduleNormalizationTransition(this.nextNormalizationLinearGain, this.scheduledEndTime)
+    }
+
+    if (crossfadeSec > 0 && this.sourceGainNode && this.nextSourceGainNode) {
+      // Overlap window: ramp the outgoing source down and the incoming source up together, both
+      // ending exactly at scheduledEndTime — the instant the current source's buffer runs out and
+      // its onended fires performGaplessTransition, by which point the outgoing gain is already 0.
+      this.sourceGainNode.gain.setValueAtTime(1, nextStartTime)
+      this.sourceGainNode.gain.linearRampToValueAtTime(0, this.scheduledEndTime)
+      this.nextSourceGainNode.gain.setValueAtTime(0, nextStartTime)
+      this.nextSourceGainNode.gain.linearRampToValueAtTime(1, this.scheduledEndTime)
+      this.crossfadeRampStartTime = nextStartTime
     }
 
     // Set up ended handler for the NEXT track (not current)
@@ -6387,6 +6529,7 @@ export class AudioEngine {
 
     const nextBuffer = this.nextBuffer
     const nextSourceNode = this.nextSourceNode
+    const nextSourceGainNode = this.nextSourceGainNode
     const nextNormalization = this.getPendingNextNormalization()
     const nextNormalizationAnalysis = this.nextNormalizationAnalysis
     const nextReplayGainDb = this.nextReplayGainDb
@@ -6404,14 +6547,20 @@ export class AudioEngine {
     // Swap source nodes
     if (this.sourceNode) {
       this.sourceNode.onended = null
-      this.disconnectSourceRouting(this.sourceNode)
+      this.disconnectSourceRouting(this.sourceGainNode)
       try {
         this.sourceNode.buffer = null
         this.sourceNode.disconnect()
+        this.sourceGainNode?.disconnect()
       } catch { /* ignore */ }
     }
     this.sourceNode = nextSourceNode
+    this.sourceGainNode = nextSourceGainNode
     this.nextSourceNode = null
+    this.nextSourceGainNode = null
+    // Any crossfade ramp just armed belonged to the outgoing source's automation timeline; the
+    // newly promoted source hasn't had one scheduled on it yet.
+    this.crossfadeRampStartTime = null
 
     // Update timing
     this.startTime = this.scheduledEndTime
@@ -6460,14 +6609,15 @@ export class AudioEngine {
     const nextNormalizationAnalysis = this.nextNormalizationAnalysis
     const pendingNextNormalization = this.getPendingNextNormalization()
     const oldSource = this.sourceNode
+    const oldSourceGainNode = this.sourceGainNode
 
     // Discard the future-scheduled gapless source (if any) and reset its normalization ramp.
     this.cancelScheduledNext()
 
     // Build and immediately start the new current source from the prebuffered buffer.
-    const newSource = this.context.createBufferSource()
-    newSource.buffer = nextBuffer
-    this.connectSourceWithRouting(newSource, nextBuffer.numberOfChannels)
+    const newSource = this.createTrackSourceNode(nextBuffer)
+    const newSourceGainNode = this.createTrackSourceGainNode(newSource)
+    this.connectSourceWithRouting(newSourceGainNode, nextBuffer.numberOfChannels)
     this.connectSourceToAnalysisTap(newSource, nextBuffer.numberOfChannels)
     newSource.onended = () => {
       if (this._playbackState === 'playing') {
@@ -6489,10 +6639,11 @@ export class AudioEngine {
       fade.linearRampToValueAtTime(1, now + declickSec * 2)
     }
     oldSource.onended = () => {
-      this.disconnectSourceRouting(oldSource)
+      this.disconnectSourceRouting(oldSourceGainNode)
       try {
         oldSource.buffer = null
         oldSource.disconnect()
+        oldSourceGainNode?.disconnect()
       } catch { /* ignore */ }
     }
     try {
@@ -6510,6 +6661,7 @@ export class AudioEngine {
     this.nextReplayGainDb = null
 
     this.sourceNode = newSource
+    this.sourceGainNode = newSourceGainNode
     this.nextSourceNode = null
 
     // The new track starts at "now" from offset 0.
@@ -6556,12 +6708,23 @@ export class AudioEngine {
     if (this.nextSourceNode) {
       try {
         this.nextSourceNode.onended = null
-        this.disconnectSourceRouting(this.nextSourceNode)
+        this.disconnectSourceRouting(this.nextSourceGainNode)
         this.nextSourceNode.stop()
         this.nextSourceNode.buffer = null
         this.nextSourceNode.disconnect()
+        this.nextSourceGainNode?.disconnect()
       } catch { /* ignore */ }
       this.nextSourceNode = null
+      this.nextSourceGainNode = null
+    }
+    // A crossfade may have been armed on the (still-playing) current source for the transition
+    // just discarded — undo it surgically so the track doesn't fade to silence with no next track
+    // to hand off to.
+    if (this.crossfadeRampStartTime != null) {
+      if (this.sourceGainNode && this.context && this.context.currentTime < this.crossfadeRampStartTime) {
+        this.sourceGainNode.gain.cancelScheduledValues(this.crossfadeRampStartTime)
+      }
+      this.crossfadeRampStartTime = null
     }
     this.restoreCurrentNormalizationGainNow()
     this.scheduledEndTime = 0
@@ -6592,6 +6755,7 @@ export class AudioEngine {
 
       if (remoteState.started && remoteState.paused) {
         remoteState.paused = false
+        this.resyncFadeGainNodeToFull()
         this.remoteStreamNode?.port.postMessage({
           type: 'set-playing',
           playing: true
@@ -6630,6 +6794,12 @@ export class AudioEngine {
       this.emit('stateChange', this._playbackState)
       this.startTimeUpdate()
       this.rampFadeGain(1, PLAYBACK_FADE_MS)
+      // pause() may have frozen sourceGainNode mid-ramp (cancelAndHoldAtTime) below 1 — e.g. a
+      // crossfade-out or queue-end fade-out in flight. Bring it back to 1 too, or the track stays
+      // silent (or partially attenuated) even though fadeGainNode is back at full volume.
+      if (this.sourceGainNode) {
+        this.rampGainNode(this.sourceGainNode, 1, PLAYBACK_FADE_MS)
+      }
       if (this.nextBuffer) {
         this.scheduleGaplessTransition()
       }
@@ -6646,9 +6816,9 @@ export class AudioEngine {
     this.stopSource()
 
     // Create new source
-    this.sourceNode = this.context.createBufferSource()
-    this.sourceNode.buffer = this.audioBuffer
-    this.connectSourceWithRouting(this.sourceNode, this.audioBuffer.numberOfChannels)
+    this.sourceNode = this.createTrackSourceNode(this.audioBuffer)
+    this.sourceGainNode = this.createTrackSourceGainNode(this.sourceNode)
+    this.connectSourceWithRouting(this.sourceGainNode, this.audioBuffer.numberOfChannels)
     this.connectSourceToAnalysisTap(this.sourceNode, this.audioBuffer.numberOfChannels)
 
     // Handle track end
@@ -6661,8 +6831,25 @@ export class AudioEngine {
     // Start from pause position, fading in from silence so the start is not abrupt.
     const offset = this.pauseTime
     this.startTime = this.context.currentTime - offset
-    if (this.fadeGainNode) {
-      const fadeStart = this.context.currentTime
+    const fadeStart = this.context.currentTime
+    const useConfiguredFadeIn = (
+      this.isFadeCrossfadeAllowed() &&
+      this.fadeSettings.fadeEnabled &&
+      this.fadeSettings.fadeInDurationMs > 0
+    )
+    if (useConfiguredFadeIn) {
+      // The configured fade-in takes over the declick node's job for this start; pin it flat so
+      // it doesn't stack a second, shorter ramp on top of sourceGainNode's longer one.
+      if (this.fadeGainNode) {
+        this.fadeGainNode.gain.cancelScheduledValues(fadeStart)
+        this.fadeGainNode.gain.setValueAtTime(1, fadeStart)
+      }
+      if (this.sourceGainNode) {
+        this.sourceGainNode.gain.cancelScheduledValues(fadeStart)
+        this.sourceGainNode.gain.setValueAtTime(0, fadeStart)
+        this.sourceGainNode.gain.linearRampToValueAtTime(1, fadeStart + this.fadeSettings.fadeInDurationMs / 1000)
+      }
+    } else if (this.fadeGainNode) {
       this.fadeGainNode.gain.cancelScheduledValues(fadeStart)
       this.fadeGainNode.gain.setValueAtTime(0, fadeStart)
       this.fadeGainNode.gain.linearRampToValueAtTime(1, fadeStart + PLAYBACK_FADE_MS / 1000)
@@ -6673,9 +6860,16 @@ export class AudioEngine {
     this.emit('stateChange', this._playbackState)
     this.startTimeUpdate()
 
-    // If we have a next buffer, schedule the gapless transition
+    // If we have a next buffer, schedule the gapless transition; otherwise, if fade-out is
+    // configured, arm it now so the track fades to silence right as it naturally ends.
     if (this.nextBuffer) {
       this.scheduleGaplessTransition()
+    } else if (
+      this.isFadeCrossfadeAllowed() &&
+      this.fadeSettings.fadeEnabled &&
+      this.fadeSettings.fadeOutDurationMs > 0
+    ) {
+      this.scheduleFadeOutForQueueEnd()
     }
   }
 
@@ -6692,6 +6886,76 @@ export class AudioEngine {
     gain.cancelScheduledValues(now)
     gain.setValueAtTime(current, now)
     gain.linearRampToValueAtTime(target, now + durationMs / 1000)
+  }
+
+  // Same ramp shape as rampFadeGain, for a caller-supplied node (the per-source gain).
+  private rampGainNode(node: GainNode, target: number, durationMs: number): void {
+    if (!this.context) return
+    const now = this.context.currentTime
+    const gain = node.gain
+    const current = gain.value
+    gain.cancelScheduledValues(now)
+    gain.setValueAtTime(current, now)
+    gain.linearRampToValueAtTime(target, now + durationMs / 1000)
+  }
+
+  // Freezes fadeGainNode at its true interpolated value (cancelAndHoldAtTime — same technique as
+  // pause()'s sourceGainNode freeze) then ramps it back to full volume. Call this before a
+  // remote/progressive stream starts producing audio: unlike the standard cold-start path, this
+  // one never otherwise re-arms the shared declick node, so a track can start fully "playing"
+  // while fadeGainNode is still sitting wherever a previous track's pause fade left it.
+  private resyncFadeGainNodeToFull(): void {
+    if (!this.context || !this.fadeGainNode) return
+    const now = this.context.currentTime
+    this.fadeGainNode.gain.cancelAndHoldAtTime(now)
+    this.fadeGainNode.gain.linearRampToValueAtTime(1, now + REMOTE_STREAM_FADE_RESYNC_MS / 1000)
+  }
+
+  // Arms a ramp on sourceGainNode so the current track fades to silence exactly as its buffer
+  // runs out. Scheduled up front, sample-accurately, like scheduledEndTime for gapless — by the
+  // time the source's onended fires the buffer has already finished producing samples, so ramping
+  // at that point would be inaudible. Only called when play() finds no next track queued; if one
+  // arrives later, scheduleGaplessTransition cancels this via cancelQueueEndFadeOut.
+  private scheduleFadeOutForQueueEnd(): void {
+    if (!this.context || !this.sourceGainNode || !this.audioBuffer) return
+    const fadeOutSec = this.fadeSettings.fadeOutDurationMs / 1000
+    if (fadeOutSec <= 0) return
+
+    const now = this.context.currentTime
+    const remaining = Math.max(0, this.audioBuffer.duration - this.currentTime)
+    // Too little of the track left for a fade to mean anything — and without this guard, a
+    // near-zero remaining collapses rampStartTime and rampEndTime onto the same instant, which
+    // cuts straight to silence instead of fading. Leave the source at whatever gain it already has.
+    if (remaining < FADE_OUT_MIN_REMAINING_SEC) return
+
+    // When remaining is shorter than the configured fadeOutDurationMs, this clamps rampStartTime
+    // to `now` so the fade spans exactly `remaining` instead of overshooting into the past.
+    const rampStartTime = now + Math.max(0, remaining - fadeOutSec)
+    const rampEndTime = now + remaining
+
+    this.sourceGainNode.gain.setValueAtTime(1, rampStartTime)
+    this.sourceGainNode.gain.linearRampToValueAtTime(0, rampEndTime)
+    this.queueEndFadeOutRampStartTime = rampStartTime
+  }
+
+  // Undoes a still-pending scheduleFadeOutForQueueEnd ramp (a next track showed up after all).
+  // Cancels from the ramp's own anchor time, not `now`, so an earlier, unrelated fade-in ramp on
+  // the same node is left untouched. No-op once the fade-out window has already started — too
+  // late to walk back cleanly, and the window is narrow enough in practice to accept as-is.
+  private cancelQueueEndFadeOut(): void {
+    const rampStartTime = this.queueEndFadeOutRampStartTime
+    if (rampStartTime == null) return
+    this.queueEndFadeOutRampStartTime = null
+    if (!this.context || !this.sourceGainNode) return
+    if (this.context.currentTime >= rampStartTime) return
+    this.sourceGainNode.gain.cancelScheduledValues(rampStartTime)
+  }
+
+  private clearFadeOutStopTimer(): void {
+    if (this.fadeOutStopTimer != null) {
+      clearTimeout(this.fadeOutStopTimer)
+      this.fadeOutStopTimer = null
+    }
   }
 
   private clearPauseFadeTimer(): void {
@@ -6736,6 +7000,24 @@ export class AudioEngine {
 
     // Record the pause position now so the seek bar/time stay correct while the audio fades out.
     this.pauseTime = this.context.currentTime - this.startTime
+
+    // Freeze any in-progress ramp on the per-source gain (crossfade-out or queue-end fade-out)
+    // unconditionally — cancelScheduledNext's crossfade cleanup only fires when we're still
+    // before crossfadeRampStartTime, so it misses a ramp that's already mid-flight, and it never
+    // knew about queueEndFadeOutRampStartTime at all. Without this, a still-running ramp keeps
+    // heading to 0 in the background regardless of pause/resume, leaving the track silent even
+    // after "Rapid resume" restores fadeGainNode. cancelAndHoldAtTime freezes the param at its
+    // true interpolated value instead of a timestamp comparison, so it works regardless of which
+    // ramp (if any) was active or how far into it we are.
+    // Note: Chromium has historically jumped cancelAndHoldAtTime to the ramp's *target* value
+    // instead of the true interpolated one (see rampFadeGain's comment below) — worth rechecking
+    // if resume ever produces an audible jump instead of a smooth continuation.
+    if (this.sourceGainNode) {
+      this.sourceGainNode.gain.cancelAndHoldAtTime(this.context.currentTime)
+    }
+    this.crossfadeRampStartTime = null
+    this.queueEndFadeOutRampStartTime = null
+
     this.cancelScheduledNext() // Cancel scheduled next track
 
     this._playbackState = 'paused'
@@ -6767,6 +7049,7 @@ export class AudioEngine {
   stop(): void {
     this.invalidateLoadOperations()
     this.clearPauseFadeTimer()
+    this.clearFadeOutStopTimer()
     const stopLoadGeneration = this.loadGeneration
     if (this.playbackOutputMode === 'bitperfect') {
       this.nativeNextTrackBuffered = false
@@ -6802,6 +7085,33 @@ export class AudioEngine {
 
     if (this.parallaxSinkState) {
       this.stopParallaxSinkPlayback()
+      return
+    }
+
+    if (
+      this.isFadeCrossfadeAllowed() &&
+      this.fadeSettings.fadeEnabled &&
+      this.fadeSettings.fadeOutDurationMs > 0 &&
+      this.context &&
+      this.sourceGainNode &&
+      this._playbackState === 'playing'
+    ) {
+      // Fade the currently audible source out, then tear it down once it's silent — same
+      // deferred-teardown shape as pause()'s rampFadeGain/pauseFadeTimer pair, but on the
+      // per-source gain so it doesn't fight a queue-end fade-out already in flight.
+      this.queueEndFadeOutRampStartTime = null
+      this.rampGainNode(this.sourceGainNode, 0, this.fadeSettings.fadeOutDurationMs)
+      this.cancelScheduledNext()
+      this.pauseTime = 0
+      this._playbackState = 'stopped'
+      this.emit('stateChange', this._playbackState)
+      this.emit('timeUpdate', 0)
+      this.stopTimeUpdate()
+      this.fadeOutStopTimer = setTimeout(() => {
+        this.fadeOutStopTimer = null
+        this.stopSource()
+        this.releaseDecodedBuffers()
+      }, this.fadeSettings.fadeOutDurationMs + FADE_STOP_EPSILON_MS)
       return
     }
 
@@ -6892,9 +7202,9 @@ export class AudioEngine {
 
     if (wasPlaying) {
       // Directly create new source and start (bypass play() state check)
-      this.sourceNode = this.context.createBufferSource()
-      this.sourceNode.buffer = this.audioBuffer
-      this.connectSourceWithRouting(this.sourceNode, this.audioBuffer.numberOfChannels)
+      this.sourceNode = this.createTrackSourceNode(this.audioBuffer)
+      this.sourceGainNode = this.createTrackSourceGainNode(this.sourceNode)
+      this.connectSourceWithRouting(this.sourceGainNode, this.audioBuffer.numberOfChannels)
       this.connectSourceToAnalysisTap(this.sourceNode, this.audioBuffer.numberOfChannels)
 
       this.sourceNode.onended = () => {
@@ -7094,12 +7404,18 @@ export class AudioEngine {
         this.sourceNode.onended = null
         this.sourceNode.stop()
         this.sourceNode.buffer = null
-        this.disconnectSourceRouting(this.sourceNode)
+        this.disconnectSourceRouting(this.sourceGainNode)
         this.sourceNode.disconnect()
+        this.sourceGainNode?.disconnect()
       } catch {
         // Ignore errors from already stopped source
       }
       this.sourceNode = null
+      this.sourceGainNode = null
+      // Any armed queue-end fade-out or crossfade belonged to the node just torn down; a stale
+      // timestamp here could wrongly cancel a legitimate ramp on whatever source comes next.
+      this.queueEndFadeOutRampStartTime = null
+      this.crossfadeRampStartTime = null
     }
   }
 
@@ -7204,6 +7520,8 @@ export class AudioEngine {
     }
 
     this.gainNode = null
+    this.sourceGainNode = null
+    this.nextSourceGainNode = null
     this.normalizationGainNode = null
     this.analysisNormalizationGainNode = null
     this.analysisDelayMs = 0

--- a/src/renderer/audio/parallaxHostDelay.test.ts
+++ b/src/renderer/audio/parallaxHostDelay.test.ts
@@ -2,17 +2,25 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { AudioEngine } from './AudioEngine.ts'
 
+interface FakeGainNode {
+  gain: { value: number }
+  connect: (destination: unknown) => void
+  disconnect: () => void
+}
+
 interface FakeSource {
   buffer: AudioBuffer | null
   onended: (() => void) | null
   starts: Array<{ when: number; offset: number }>
   start: (when: number, offset: number) => void
+  connect: (destination: unknown) => void
 }
 
 interface DelayTestEngine {
-  context: Pick<AudioContext, 'currentTime' | 'createBufferSource'>
+  context: Pick<AudioContext, 'currentTime' | 'createBufferSource' | 'createGain'>
   audioBuffer: Pick<AudioBuffer, 'duration' | 'numberOfChannels'>
   sourceNode: FakeSource | null
+  sourceGainNode: FakeGainNode | null
   playbackOutputMode: 'standard'
   _playbackState: 'playing'
   pauseTime: number
@@ -35,21 +43,25 @@ function createPendingStartEngine(): {
     starts: [],
     start(when, offset) {
       this.starts.push({ when, offset })
-    }
+    },
+    connect: () => undefined
   }
   let oldSourceStopped = false
   const internals = engine as unknown as DelayTestEngine
   internals.context = {
     currentTime: 10,
-    createBufferSource: () => replacementSource as unknown as AudioBufferSourceNode
+    createBufferSource: () => replacementSource as unknown as AudioBufferSourceNode,
+    createGain: () => ({ gain: { value: 1 }, connect: () => undefined, disconnect: () => undefined } as unknown as GainNode)
   }
   internals.audioBuffer = { duration: 180, numberOfChannels: 2 }
   internals.sourceNode = {
     buffer: internals.audioBuffer as AudioBuffer,
     onended: null,
     starts: [],
-    start: () => undefined
+    start: () => undefined,
+    connect: () => undefined
   }
+  internals.sourceGainNode = { gain: { value: 1 }, connect: () => undefined, disconnect: () => undefined }
   internals.playbackOutputMode = 'standard'
   internals._playbackState = 'playing'
   internals.pauseTime = 12

--- a/src/renderer/components/layout/InfoSidebar.tsx
+++ b/src/renderer/components/layout/InfoSidebar.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { LastFmArtistInfo } from '../../../types/lastFm'
 import { usePlayerStore } from '../../stores/playerStore'
+import { useLibraryStore } from '../../stores/libraryStore'
 import { useUIStore } from '../../stores/uiStore'
 import { useOpenArtistInLibrary } from '../../hooks/useOpenArtistInLibrary'
 import { useOpenAlbumInLibrary } from '../../hooks/useOpenAlbumInLibrary'
@@ -7,6 +9,7 @@ import { usePlaybackClock } from '../../hooks/usePlaybackClock'
 import { useLyricsSyncedView } from '../../hooks/useLyricsSyncedView'
 import AlbumArtwork from '../library/AlbumArtwork'
 import ArtistNameLinks from '../library/ArtistNameLinks'
+import { normalizeKey } from '../../utils/albumIdentity'
 import { useLyricsStore } from '../../stores/lyricsStore'
 import { useAudioSettingsStore } from '../../stores/audioSettingsStore'
 import { useLyricsDisplaySettingsStore } from '../../stores/lyricsDisplaySettingsStore'
@@ -22,10 +25,17 @@ import {
   resolveLyricsBodyState
 } from '../../utils/lyricsPresentation'
 
-type InfoSidebarTab = 'info' | 'lyrics'
+type InfoSidebarTab = 'info' | 'lyrics' | 'bio'
+
+type ArtistBioState =
+  | { status: 'no-artist' }
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; artist: LastFmArtistInfo }
 
 export default function InfoSidebar() {
   const currentTrack = usePlayerStore((s) => s.currentTrack)
+  const libraryArtists = useLibraryStore((s) => s.artists)
   const currentTime = usePlaybackClock(0.1)
   const duration = usePlayerStore((s) => s.duration)
   const seek = usePlayerStore((s) => s.seek)
@@ -35,6 +45,10 @@ export default function InfoSidebar() {
   const openArtistInLibrary = useOpenArtistInLibrary()
   const openAlbumInLibrary = useOpenAlbumInLibrary()
   const [activeTab, setActiveTab] = useState<InfoSidebarTab>('info')
+  const [isGenreExpanded, setIsGenreExpanded] = useState(false)
+  const [bioState, setBioState] = useState<ArtistBioState>({ status: 'no-artist' })
+  const [isBioTagsExpanded, setIsBioTagsExpanded] = useState(false)
+  const artistBioCacheRef = useRef<Map<string, LastFmArtistInfo>>(new Map())
   const lyricsTrackPath = useLyricsStore((s) => s.currentTrackPath)
   const lyricsResult = useLyricsStore((s) => s.currentResult)
   const lyricsIsLoading = useLyricsStore((s) => s.isLoading)
@@ -91,6 +105,46 @@ export default function InfoSidebar() {
     if (activeTab !== 'lyrics') return
     void loadLyricsForTrack(lyricsQuery)
   }, [activeTab, lyricsQuery, loadLyricsForTrack])
+
+  useEffect(() => {
+    if (activeTab !== 'bio') return
+
+    setIsBioTagsExpanded(false)
+    const artistName = currentTrack?.artist.trim()
+    if (!artistName) {
+      setBioState({ status: 'no-artist' })
+      return
+    }
+
+    const cached = artistBioCacheRef.current.get(artistName)
+    if (cached) {
+      setBioState({ status: 'success', artist: cached })
+      return
+    }
+
+    let cancelled = false
+    setBioState({ status: 'loading' })
+
+    window.electronAPI.lastFm.getArtistInfo(artistName)
+      .then((result) => {
+        if (cancelled) return
+        if (!result.ok) {
+          setBioState({ status: 'error', message: result.message })
+          return
+        }
+
+        artistBioCacheRef.current.set(artistName, result.artist)
+        setBioState({ status: 'success', artist: result.artist })
+      })
+      .catch(() => {
+        if (cancelled) return
+        setBioState({ status: 'error', message: 'Failed to load artist biography.' })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeTab, currentTrack?.artist])
 
   const revealTrackInFolder = () => {
     if (!currentTrack) return
@@ -187,8 +241,53 @@ export default function InfoSidebar() {
     )
   }
 
+  const renderBioContent = () => {
+    if (bioState.status === 'no-artist') {
+      return <div className="info-lyrics-state">No artist selected.</div>
+    }
+
+    if (bioState.status === 'loading') {
+      return <div className="info-lyrics-state">Chargement...</div>
+    }
+
+    if (bioState.status === 'error') {
+      return <div className="info-lyrics-state info-lyrics-state-error">{bioState.message}</div>
+    }
+
+    const { artist } = bioState
+    const libraryArtistKey = normalizeKey(artist.name)
+    const libraryArtistRecord = libraryArtists.find((libraryArtist) => normalizeKey(libraryArtist.artist) === libraryArtistKey) ?? null
+    const libraryArtworkHash = libraryArtistRecord?.artwork_hash ?? null
+
+    return (
+      <>
+        <div className="info-bio-artwork">
+          {libraryArtworkHash && <AlbumArtwork hash={libraryArtworkHash} alt={artist.name} />}
+        </div>
+        <h2 className="info-bio-name">{artist.name}</h2>
+        {artist.tags.length > 0 && (
+          <div className="info-meta-row">
+            <span className="info-meta-label">Genre</span>
+            <span
+              className={`info-meta-value info-meta-value--clickable ${isBioTagsExpanded ? 'info-meta-value--wrap' : ''}`}
+              onClick={() => setIsBioTagsExpanded(!isBioTagsExpanded)}
+              title="Cliquer pour tout voir"
+            >
+              {artist.tags.join(', ')}
+            </span>
+          </div>
+        )}
+        {artist.bio ? (
+          <p className="info-bio-text">{artist.bio}</p>
+        ) : (
+          <div className="info-lyrics-state">No biography available.</div>
+        )}
+      </>
+    )
+  }
+
   return (
-    <aside className={`info-sidebar${activeTab === 'lyrics' ? ' info-sidebar-lyrics-active' : ''}`}>
+    <aside className={`info-sidebar${activeTab === 'lyrics' || activeTab === 'bio' ? ' info-sidebar-lyrics-active' : ''}`}>
       <div className="info-sidebar-header">
         <span className="info-sidebar-label">NOW PLAYING</span>
         <div className="info-sidebar-header-actions">
@@ -232,6 +331,13 @@ export default function InfoSidebar() {
         >
           Lyrics
         </button>
+        <button
+          type="button"
+          className={`info-sidebar-tab ${activeTab === 'bio' ? 'active' : ''}`}
+          onClick={() => setActiveTab('bio')}
+        >
+          Bio
+        </button>
       </div>
 
       {activeTab === 'lyrics' ? (
@@ -256,6 +362,10 @@ export default function InfoSidebar() {
             </button>
           </div>
           {renderLyricsContent()}
+        </div>
+      ) : activeTab === 'bio' ? (
+        <div className="info-bio-panel">
+          {renderBioContent()}
         </div>
       ) : currentTrack ? (
         <>
@@ -309,14 +419,20 @@ export default function InfoSidebar() {
             </div>
             {currentTrack.year && (
               <div className="info-meta-row">
-                <span className="info-meta-label">Year</span>
-                <span className="info-meta-value">{currentTrack.year}</span>
+                <span className="info-meta-label">Release Date</span>
+                <span className="info-meta-value">{currentTrack.date || currentTrack.year}</span>
               </div>
             )}
             {currentTrack.genre && (
               <div className="info-meta-row">
                 <span className="info-meta-label">Genre</span>
-                <span className="info-meta-value">{currentTrack.genre}</span>
+                <span
+                  className={`info-meta-value info-meta-value--clickable ${isGenreExpanded ? 'info-meta-value--wrap' : ''}`}
+                  onClick={() => setIsGenreExpanded(!isGenreExpanded)}
+                  title="Cliquer pour tout voir"
+                >
+                  {currentTrack.genre}
+                </span>
               </div>
             )}
             {currentTrack.trackNumber && (

--- a/src/renderer/components/layout/TransportBar.tsx
+++ b/src/renderer/components/layout/TransportBar.tsx
@@ -638,7 +638,9 @@ export default function TransportBar() {
           disabled={eqControlDisabled}
         >
           <span className="transport-eq-label">EQ</span>
-          <EQResponsePreview className="transport-eq-curve" width={80} height={30} showFill={false} />
+          <div className="transport-eq-graphic-slot">
+            <EQResponsePreview className="transport-eq-curve" width={80} height={30} showFill={false} />
+          </div>
         </button>
 
         {/* Queue + Info stacked vertically */}
@@ -695,6 +697,7 @@ export default function TransportBar() {
           onClose={() => setShowEQPopover(false)}
         />
       )}
+
     </div>
   )
 }

--- a/src/renderer/components/library/AlbumGrid.tsx
+++ b/src/renderer/components/library/AlbumGrid.tsx
@@ -12,6 +12,8 @@ import {
   resolveGridHorizontalInset,
   resolveVirtualGridContentWidth
 } from '../../utils/virtualGridSizing'
+import { useLibraryStore } from '../../stores/libraryStore'
+import { DEFAULT_ALBUM_GRID_SCALE_PERCENT, useUIStore } from '../../stores/uiStore'
 
 interface AlbumRecord {
   identity_key: string
@@ -41,16 +43,17 @@ interface AlbumGridCellSharedProps {
   onSelectAlbum: (album: AlbumRecord) => void
   onAlbumContextMenu: (album: AlbumRecord, x: number, y: number) => void
   searchQuery: string
+  showYear: boolean
 }
 
-const ALBUM_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX = 160
+export const ALBUM_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX = 160
 const ALBUM_GRID_GAP_FALLBACK_PX = 14
 const ALBUM_GRID_PADDING_FALLBACK_PX = 14
 const ALBUM_GRID_OVERSCAN_COUNT = 3
 // Card chrome that stacks on top of the square artwork: card padding + borders
 // + artwork margin + three single-line info rows. Only used until the first
 // mounted card is measured.
-const ALBUM_CARD_NON_ARTWORK_HEIGHT_ESTIMATE_PX = 91
+export const ALBUM_CARD_NON_ARTWORK_HEIGHT_ESTIMATE_PX = 91
 
 function resolveCssPx(element: HTMLElement | null, propertyName: string, fallback: number): number {
   if (!element) return fallback
@@ -77,7 +80,8 @@ function AlbumGridCellRenderer({
   columnCount,
   onSelectAlbum,
   onAlbumContextMenu,
-  searchQuery
+  searchQuery,
+  showYear
 }: CellComponentProps<AlbumGridCellSharedProps>): ReactElement | null {
   const albumIndex = (rowIndex * columnCount) + columnIndex
   const album = albums[albumIndex]
@@ -117,7 +121,7 @@ function AlbumGridCellRenderer({
         <div className="album-info">
           <div className="album-title">{highlightSearchMatch(album.album, searchQuery)}</div>
           <div className="album-artist">{highlightSearchMatch(album.artist, searchQuery)}</div>
-          <div className="album-meta">{formatTrackCount(album.track_count)}{album.year ? ` • ${album.year}` : ''}</div>
+          <div className="album-meta">{formatTrackCount(album.track_count)}{showYear && album.year ? ` • ${album.year}` : ''}</div>
         </div>
       </div>
     </div>
@@ -143,6 +147,8 @@ export default function AlbumGrid({
   const [measuredCardHeight, setMeasuredCardHeight] = useState<number | null>(null)
   const bodyRef = useRef<HTMLDivElement | null>(null)
   const gridApiRef = useRef<GridImperativeAPI | null>(null)
+  const albumGridScalePercent = useUIStore((state) => state.albumGridScalePercent)
+  const showAlbumGridYear = useLibraryStore((state) => state.showAlbumGridYear)
 
   useImperativeHandle(viewportRef, () => ({
     get element() {
@@ -150,45 +156,68 @@ export default function AlbumGrid({
     }
   }), [])
 
+  const measureGridMetrics = useCallback(() => {
+    const element = bodyRef.current
+    if (!element) return
+
+    const nextHeight = Math.max(0, Math.round(element.clientHeight))
+    const nextWidth = Math.max(0, Math.round(element.clientWidth))
+    const nextMinColumnWidth = resolveCssPx(element, '--album-grid-min-column-width', ALBUM_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX)
+    const nextGap = resolveCssPx(element, '--album-grid-gap', ALBUM_GRID_GAP_FALLBACK_PX)
+    const nextPadding = resolveCssPx(element, '--album-grid-padding', ALBUM_GRID_PADDING_FALLBACK_PX)
+
+    setViewportSize((previous) => (
+      previous.height === nextHeight && previous.width === nextWidth
+        ? previous
+        : { height: nextHeight, width: nextWidth }
+    ))
+    setMinColumnWidth((previous) => (previous === nextMinColumnWidth ? previous : nextMinColumnWidth))
+    setGap((previous) => (previous === nextGap ? previous : nextGap))
+    setPadding((previous) => (previous === nextPadding ? previous : nextPadding))
+  }, [])
+
+  // Overrides the CSS default directly on the grid's own element (an inline style here always
+  // wins over the .album-grid-shell rule, regardless of any responsive breakpoint) so a custom
+  // scale doesn't require touching resolveCssPx or resolveArtistGridLayout. At the default 100%
+  // the override is removed entirely, leaving the stylesheet (and its breakpoints) in control.
   useLayoutEffect(() => {
     const element = bodyRef.current
     if (!element) return
 
-    const updateMeasurements = () => {
-      const nextHeight = Math.max(0, Math.round(element.clientHeight))
-      const nextWidth = Math.max(0, Math.round(element.clientWidth))
-      const nextMinColumnWidth = resolveCssPx(element, '--album-grid-min-column-width', ALBUM_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX)
-      const nextGap = resolveCssPx(element, '--album-grid-gap', ALBUM_GRID_GAP_FALLBACK_PX)
-      const nextPadding = resolveCssPx(element, '--album-grid-padding', ALBUM_GRID_PADDING_FALLBACK_PX)
-
-      setViewportSize((previous) => (
-        previous.height === nextHeight && previous.width === nextWidth
-          ? previous
-          : { height: nextHeight, width: nextWidth }
-      ))
-      setMinColumnWidth((previous) => (previous === nextMinColumnWidth ? previous : nextMinColumnWidth))
-      setGap((previous) => (previous === nextGap ? previous : nextGap))
-      setPadding((previous) => (previous === nextPadding ? previous : nextPadding))
+    if (albumGridScalePercent === DEFAULT_ALBUM_GRID_SCALE_PERCENT) {
+      element.style.removeProperty('--album-grid-min-column-width')
+    } else {
+      const scaledWidth = Math.round(
+        ALBUM_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX * (albumGridScalePercent / 100)
+      )
+      element.style.setProperty('--album-grid-min-column-width', `${scaledWidth}px`)
     }
 
-    updateMeasurements()
+    measureGridMetrics()
+  }, [albumGridScalePercent, measureGridMetrics])
+
+  useLayoutEffect(() => {
+    const element = bodyRef.current
+    if (!element) return
+
+    measureGridMetrics()
 
     if (typeof ResizeObserver === 'undefined') {
-      window.addEventListener('resize', updateMeasurements)
+      window.addEventListener('resize', measureGridMetrics)
       return () => {
-        window.removeEventListener('resize', updateMeasurements)
+        window.removeEventListener('resize', measureGridMetrics)
       }
     }
 
     const resizeObserver = new ResizeObserver(() => {
-      updateMeasurements()
+      measureGridMetrics()
     })
     resizeObserver.observe(element)
 
     return () => {
       resizeObserver.disconnect()
     }
-  }, [])
+  }, [measureGridMetrics])
 
   // Cells carry gap/2 padding on every side; the scroller adds
   // (padding - gap/2) so outer edges land at the CSS-grid padding. Prefer the
@@ -257,8 +286,9 @@ export default function AlbumGrid({
     columnCount: gridLayout.columnCount,
     onSelectAlbum,
     onAlbumContextMenu,
-    searchQuery
-  }), [albums, gridLayout.columnCount, onAlbumContextMenu, onSelectAlbum, searchQuery])
+    searchQuery,
+    showYear: showAlbumGridYear
+  }), [albums, gridLayout.columnCount, onAlbumContextMenu, onSelectAlbum, searchQuery, showAlbumGridYear])
 
   useEffect(() => {
     const group = bodyRef.current

--- a/src/renderer/components/library/ArtistList.tsx
+++ b/src/renderer/components/library/ArtistList.tsx
@@ -10,8 +10,9 @@ import {
   type ControllerVirtualMoveDetail
 } from '../../utils/controllerFocus'
 import { resolveVirtualGridContentWidth } from '../../utils/virtualGridSizing'
+import { DEFAULT_ARTIST_GRID_SCALE_PERCENT, useUIStore } from '../../stores/uiStore'
 
-interface ArtistRecord {
+export interface ArtistRecord {
   artist: string
   track_count: number
   album_count: number
@@ -47,8 +48,9 @@ interface ArtistGridCellSharedProps {
 
 const ARTIST_ROW_HEIGHT_FALLBACK_PX = 64
 const ARTIST_LIST_OVERSCAN_COUNT = 8
-const ARTIST_GRID_ROW_HEIGHT_FALLBACK_PX = 168
-const ARTIST_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX = 124
+export const ARTIST_GRID_ROW_HEIGHT_FALLBACK_PX = 168
+export const ARTIST_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX = 124
+export const ARTIST_GRID_AVATAR_HEIGHT_FALLBACK_PX = 96
 const ARTIST_GRID_GAP_FALLBACK_PX = 12
 const ARTIST_GRID_OVERSCAN_COUNT = 3
 
@@ -78,7 +80,7 @@ function getArtistInitial(artist: string): string {
   return artist.trim().charAt(0).toUpperCase()
 }
 
-function ArtistAvatar({
+export function ArtistAvatar({
   artist,
   className,
   artworkClassName,
@@ -212,6 +214,7 @@ export default function ArtistList({
   const listBodyRef = useRef<HTMLDivElement | null>(null)
   const listApiRef = useRef<ListImperativeAPI | null>(null)
   const gridApiRef = useRef<GridImperativeAPI | null>(null)
+  const artistGridScalePercent = useUIStore((state) => state.artistGridScalePercent)
 
   useImperativeHandle(viewportRef, () => ({
     get element() {
@@ -221,47 +224,77 @@ export default function ArtistList({
     }
   }), [viewMode])
 
+  const measureListMetrics = useCallback(() => {
+    const element = listBodyRef.current
+    if (!element) return
+
+    const nextHeight = Math.max(0, Math.round(element.clientHeight))
+    const nextWidth = Math.max(0, Math.round(element.clientWidth))
+    const nextRowHeight = resolveCssPx(element, '--artist-row-height', ARTIST_ROW_HEIGHT_FALLBACK_PX)
+    const nextGridRowHeight = resolveCssPx(element, '--artist-grid-row-height', ARTIST_GRID_ROW_HEIGHT_FALLBACK_PX)
+    const nextGridMinColumnWidth = resolveCssPx(element, '--artist-grid-min-column-width', ARTIST_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX)
+    const nextGridGap = resolveCssPx(element, '--artist-grid-gap', ARTIST_GRID_GAP_FALLBACK_PX)
+
+    setViewportSize((previous) => (
+      previous.height === nextHeight && previous.width === nextWidth
+        ? previous
+        : { height: nextHeight, width: nextWidth }
+    ))
+    setArtistRowHeight((previous) => (previous === nextRowHeight ? previous : nextRowHeight))
+    setArtistGridRowHeight((previous) => (previous === nextGridRowHeight ? previous : nextGridRowHeight))
+    setArtistGridMinColumnWidth((previous) => (previous === nextGridMinColumnWidth ? previous : nextGridMinColumnWidth))
+    setArtistGridGap((previous) => (previous === nextGridGap ? previous : nextGridGap))
+  }, [])
+
+  // Same reasoning as AlbumGrid: override directly on this element (always wins over the
+  // .artist-list rule) so a custom scale doesn't require touching resolveCssPx or
+  // resolveArtistGridLayout. At 100% the overrides are removed, leaving the stylesheet — and its
+  // narrow-window breakpoint for these three variables — in control. Row height and avatar height
+  // scale by the same percentage as column width so cards grow/shrink proportionally in both
+  // dimensions, matching how the album grid's auto-measured card height already tracks its width.
   useLayoutEffect(() => {
     const element = listBodyRef.current
     if (!element) return
 
-    const updateMeasurements = () => {
-      const nextHeight = Math.max(0, Math.round(element.clientHeight))
-      const nextWidth = Math.max(0, Math.round(element.clientWidth))
-      const nextRowHeight = resolveCssPx(element, '--artist-row-height', ARTIST_ROW_HEIGHT_FALLBACK_PX)
-      const nextGridRowHeight = resolveCssPx(element, '--artist-grid-row-height', ARTIST_GRID_ROW_HEIGHT_FALLBACK_PX)
-      const nextGridMinColumnWidth = resolveCssPx(element, '--artist-grid-min-column-width', ARTIST_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX)
-      const nextGridGap = resolveCssPx(element, '--artist-grid-gap', ARTIST_GRID_GAP_FALLBACK_PX)
-
-      setViewportSize((previous) => (
-        previous.height === nextHeight && previous.width === nextWidth
-          ? previous
-          : { height: nextHeight, width: nextWidth }
-      ))
-      setArtistRowHeight((previous) => (previous === nextRowHeight ? previous : nextRowHeight))
-      setArtistGridRowHeight((previous) => (previous === nextGridRowHeight ? previous : nextGridRowHeight))
-      setArtistGridMinColumnWidth((previous) => (previous === nextGridMinColumnWidth ? previous : nextGridMinColumnWidth))
-      setArtistGridGap((previous) => (previous === nextGridGap ? previous : nextGridGap))
+    if (artistGridScalePercent === DEFAULT_ARTIST_GRID_SCALE_PERCENT) {
+      element.style.removeProperty('--artist-grid-min-column-width')
+      element.style.removeProperty('--artist-grid-row-height')
+      element.style.removeProperty('--artist-grid-avatar-height')
+    } else {
+      const scale = artistGridScalePercent / 100
+      const scaledWidth = Math.round(ARTIST_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX * scale)
+      const scaledRowHeight = Math.round(ARTIST_GRID_ROW_HEIGHT_FALLBACK_PX * scale)
+      const scaledAvatarHeight = Math.round(ARTIST_GRID_AVATAR_HEIGHT_FALLBACK_PX * scale)
+      element.style.setProperty('--artist-grid-min-column-width', `${scaledWidth}px`)
+      element.style.setProperty('--artist-grid-row-height', `${scaledRowHeight}px`)
+      element.style.setProperty('--artist-grid-avatar-height', `${scaledAvatarHeight}px`)
     }
 
-    updateMeasurements()
+    measureListMetrics()
+  }, [artistGridScalePercent, measureListMetrics])
+
+  useLayoutEffect(() => {
+    const element = listBodyRef.current
+    if (!element) return
+
+    measureListMetrics()
 
     if (typeof ResizeObserver === 'undefined') {
-      window.addEventListener('resize', updateMeasurements)
+      window.addEventListener('resize', measureListMetrics)
       return () => {
-        window.removeEventListener('resize', updateMeasurements)
+        window.removeEventListener('resize', measureListMetrics)
       }
     }
 
     const resizeObserver = new ResizeObserver(() => {
-      updateMeasurements()
+      measureListMetrics()
     })
     resizeObserver.observe(element)
 
     return () => {
       resizeObserver.disconnect()
     }
-  }, [])
+  }, [measureListMetrics])
 
   const rowProps = useMemo<ArtistListRowSharedProps>(() => ({
     artists,

--- a/src/renderer/components/library/ArtistNameLinks.tsx
+++ b/src/renderer/components/library/ArtistNameLinks.tsx
@@ -16,6 +16,7 @@ interface ArtistNameLinksProps {
 
 interface ArtistNameLinksContentProps extends ArtistNameLinksProps {
   artistBrowseMode: LibraryArtistBrowseMode
+  artistSplitExceptions?: string[]
 }
 
 function joinClasses(...classNames: Array<string | undefined>): string {
@@ -26,7 +27,8 @@ export default function ArtistNameLinks({
   ...props
 }: ArtistNameLinksProps) {
   const artistBrowseMode = useLibraryStore((state) => state.artistBrowseMode)
-  return <ArtistNameLinksContent {...props} artistBrowseMode={artistBrowseMode} />
+  const artistSplitExceptions = useLibraryStore((state) => state.artistSplitExceptions)
+  return <ArtistNameLinksContent {...props} artistBrowseMode={artistBrowseMode} artistSplitExceptions={artistSplitExceptions} />
 }
 
 // Virtualized lists can select the browse mode once at the list level instead
@@ -40,13 +42,14 @@ function ArtistNameLinksContentRenderer({
   className,
   linkClassName,
   stopPropagation = false,
-  artistBrowseMode
+  artistBrowseMode,
+  artistSplitExceptions = []
 }: ArtistNameLinksContentProps) {
   const normalizedArtistText = artistText.replace(/\s+/g, ' ').trim()
   const normalizedBrowseArtistText = (browseArtistText ?? '').replace(/\s+/g, ' ').trim()
   const parsedArtistTokens = artistNames && artistNames.length > 0
     ? buildArtistNameTokens(artistNames)
-    : parseArtistMetadata(artistText)
+    : parseArtistMetadata(artistText, artistSplitExceptions)
   const tokens = artistBrowseMode === 'canonical' ? parsedArtistTokens : []
   const containerClassName = joinClasses('artist-name-links', className)
   const buttonClassName = joinClasses('artist-name-link', linkClassName)

--- a/src/renderer/components/library/GridScalePreview.tsx
+++ b/src/renderer/components/library/GridScalePreview.tsx
@@ -1,0 +1,138 @@
+import type { CSSProperties } from 'react'
+import { useLibraryStore } from '../../stores/libraryStore'
+import { useUIStore } from '../../stores/uiStore'
+import AlbumArtwork from './AlbumArtwork'
+import { ALBUM_CARD_NON_ARTWORK_HEIGHT_ESTIMATE_PX, ALBUM_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX } from './AlbumGrid'
+import {
+  ArtistAvatar,
+  ARTIST_GRID_AVATAR_HEIGHT_FALLBACK_PX,
+  ARTIST_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX,
+  ARTIST_GRID_ROW_HEIGHT_FALLBACK_PX
+} from './ArtistList'
+
+// Sizing the box for the slider's absolute max (200%) left too much empty space at the common,
+// lower-percentage case. Reference a more modest percentage instead — the internal overflow-y:
+// auto (see globals.css) takes over above this, so nothing gets clipped, it just scrolls sooner.
+const GRID_SCALE_PREVIEW_HEIGHT_REFERENCE_PERCENT = 140
+
+// A little headroom below the card sized at the reference percentage (so the hover
+// translateY(-4px) doesn't clip) and above (padding-top in CSS covers that side). Keeps the
+// preview box a fixed size regardless of the current scale, so the rest of the card (slider,
+// toggle) never moves as it's dragged.
+const GRID_SCALE_PREVIEW_HEIGHT_BUFFER_PX = 8
+
+const ALBUM_GRID_PREVIEW_HEIGHT_PX = Math.round(
+  ALBUM_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX * (GRID_SCALE_PREVIEW_HEIGHT_REFERENCE_PERCENT / 100)
+) + ALBUM_CARD_NON_ARTWORK_HEIGHT_ESTIMATE_PX + GRID_SCALE_PREVIEW_HEIGHT_BUFFER_PX
+
+const ARTIST_GRID_PREVIEW_HEIGHT_PX = Math.round(
+  ARTIST_GRID_ROW_HEIGHT_FALLBACK_PX * (GRID_SCALE_PREVIEW_HEIGHT_REFERENCE_PERCENT / 100)
+) + GRID_SCALE_PREVIEW_HEIGHT_BUFFER_PX
+
+interface PreviewAlbum {
+  key: string
+  album: string
+  artist: string
+  year: number
+  track_count: number
+}
+
+interface PreviewArtist {
+  key: string
+  artist: string
+  track_count: number
+  album_count: number
+}
+
+const PREVIEW_ALBUMS: PreviewAlbum[] = [
+  { key: 'preview-album-1', album: 'Album Title', artist: 'Artist Name', year: 2024, track_count: 12 },
+  { key: 'preview-album-2', album: 'Second Album', artist: 'Another Artist', year: 2021, track_count: 9 },
+  { key: 'preview-album-3', album: 'Third Album', artist: 'Third Artist', year: 2019, track_count: 14 }
+]
+
+const PREVIEW_ARTISTS: PreviewArtist[] = [
+  { key: 'preview-artist-1', artist: 'Artist Name', track_count: 24, album_count: 3 },
+  { key: 'preview-artist-2', artist: 'Another Artist', track_count: 18, album_count: 2 },
+  { key: 'preview-artist-3', artist: 'Third Artist', track_count: 31, album_count: 5 }
+]
+
+function formatTrackCount(count: number): string {
+  return `${count} ${count === 1 ? 'track' : 'tracks'}`
+}
+
+function formatCount(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+function formatArtistSummary(artist: PreviewArtist): string {
+  return `${formatCount(artist.track_count, 'track', 'tracks')} · ${formatCount(artist.album_count, 'album', 'albums')}`
+}
+
+// Decorative, non-interactive stand-ins for the real grids' scale sliders — reuse the same CSS
+// classes, AlbumArtwork/ArtistAvatar (with artwork_hash: null for their native placeholder), and
+// the same base-pixel constants the real override effects scale from, so the preview always
+// matches what the grid actually renders at the current slider value.
+export function AlbumGridScalePreview() {
+  const albumGridScalePercent = useUIStore((state) => state.albumGridScalePercent)
+  const showAlbumGridYear = useLibraryStore((state) => state.showAlbumGridYear)
+  const cardWidth = Math.round(ALBUM_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX * (albumGridScalePercent / 100))
+
+  return (
+    <div
+      className="settings-grid-scale-preview"
+      style={{ height: `${ALBUM_GRID_PREVIEW_HEIGHT_PX}px` }}
+      aria-hidden="true"
+    >
+      {PREVIEW_ALBUMS.map((album) => (
+        <div key={album.key} className="album-card" style={{ width: `${cardWidth}px` }}>
+          <div className="album-artwork">
+            <AlbumArtwork hash={null} alt={album.album} variant="card" />
+          </div>
+          <div className="album-info">
+            <div className="album-title">{album.album}</div>
+            <div className="album-artist">{album.artist}</div>
+            <div className="album-meta">
+              {formatTrackCount(album.track_count)}{showAlbumGridYear ? ` • ${album.year}` : ''}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ArtistGridScalePreview() {
+  const artistGridScalePercent = useUIStore((state) => state.artistGridScalePercent)
+  const scale = artistGridScalePercent / 100
+  const cardWidth = Math.round(ARTIST_GRID_MIN_COLUMN_WIDTH_FALLBACK_PX * scale)
+  const cardHeight = Math.round(ARTIST_GRID_ROW_HEIGHT_FALLBACK_PX * scale)
+  const avatarHeight = Math.round(ARTIST_GRID_AVATAR_HEIGHT_FALLBACK_PX * scale)
+  const cardStyle = {
+    width: `${cardWidth}px`,
+    height: `${cardHeight}px`,
+    '--artist-grid-avatar-height': `${avatarHeight}px`
+  } as CSSProperties
+
+  return (
+    <div
+      className="settings-grid-scale-preview"
+      style={{ height: `${ARTIST_GRID_PREVIEW_HEIGHT_PX}px` }}
+      aria-hidden="true"
+    >
+      {PREVIEW_ARTISTS.map((artist) => (
+        <div key={artist.key} className="artist-grid-card" style={cardStyle}>
+          <ArtistAvatar
+            artist={{ artist: artist.artist, track_count: artist.track_count, album_count: artist.album_count, artwork_hash: null }}
+            className="artist-grid-avatar"
+            artworkClassName="artist-grid-avatar-artwork"
+            artworkVariant="card"
+          />
+          <div className="artist-grid-info">
+            <div className="artist-grid-name">{artist.artist}</div>
+            <div className="artist-grid-track-count">{formatArtistSummary(artist)}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/components/library/SearchControl.tsx
+++ b/src/renderer/components/library/SearchControl.tsx
@@ -1,0 +1,38 @@
+interface SearchControlProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder: string
+}
+
+export default function SearchControl({ value, onChange, placeholder }: SearchControlProps) {
+  return (
+    <div className="search-container">
+      <span className="search-icon" aria-hidden="true">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="11" cy="11" r="7" />
+          <path d="m20 20-3.5-3.5" />
+        </svg>
+      </span>
+      <input
+        type="text"
+        className="search-input"
+        data-shortcut-search="true"
+        placeholder={placeholder}
+        aria-label={placeholder}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      {value.length > 0 && (
+        <button
+          type="button"
+          className="search-clear-btn"
+          aria-label="Clear search"
+          title="Clear search"
+          onClick={() => onChange('')}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/library/TrackList.tsx
+++ b/src/renderer/components/library/TrackList.tsx
@@ -130,6 +130,7 @@ interface TrackListRowSharedProps {
   ratings: ReadonlyMap<string, TrackRatingState>
   setTrackRating: (trackPaths: string[], rating: number | null) => Promise<void>
   artistBrowseMode: LibraryArtistBrowseMode
+  artistSplitExceptions: string[]
   searchQuery: string
   trackNumberMode: TrackNumberMode
   contextTrackNumbers?: readonly number[]
@@ -446,6 +447,7 @@ function TrackListRowRenderer({
   ratings,
   setTrackRating,
   artistBrowseMode,
+  artistSplitExceptions,
   searchQuery,
   trackNumberMode,
   contextTrackNumbers,
@@ -679,6 +681,7 @@ function TrackListRowRenderer({
                 linkClassName="artist-name-link-inline"
                 stopPropagation
                 artistBrowseMode={artistBrowseMode}
+                artistSplitExceptions={artistSplitExceptions}
               />
             )}
           </div>
@@ -887,6 +890,7 @@ export default function TrackList({
   const showTracklistPlayCount = useLibraryStore((state) => state.showTracklistPlayCount)
   const ratingsEnabled = useRatingsStore((state) => state.enabled)
   const artistBrowseMode = useLibraryStore((state) => state.artistBrowseMode)
+  const artistSplitExceptions = useLibraryStore((state) => state.artistSplitExceptions)
   const ratings = useRatingsStore((state) => state.ratings)
   const setTrackRating = useRatingsStore((state) => state.setTrackRating)
   const playlists = usePlaylistStore((state) => state.playlists)
@@ -2071,6 +2075,7 @@ export default function TrackList({
     ratings,
     setTrackRating,
     artistBrowseMode,
+    artistSplitExceptions,
     searchQuery,
     trackNumberMode,
     contextTrackNumbers,
@@ -2122,6 +2127,7 @@ export default function TrackList({
     ratings,
     setTrackRating,
     artistBrowseMode,
+    artistSplitExceptions,
     searchQuery,
     trackNumberMode,
     contextTrackNumbers,

--- a/src/renderer/components/mini/MiniPlayerBackdropVisualizer.tsx
+++ b/src/renderer/components/mini/MiniPlayerBackdropVisualizer.tsx
@@ -199,9 +199,7 @@ export default function MiniPlayerBackdropVisualizer({
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const animationRef = useRef<number | null>(null)
   const drawRef = useRef<(() => void) | null>(null)
-  const [isReducedMotion, setIsReducedMotion] = useState(false)
-  const renderMode: MiniPlayerVisualizerMode = isReducedMotion ? 'off' : mode
-  const modeRef = useRef(renderMode)
+  const modeRef = useRef(mode)
   const layoutModeRef = useRef(layoutMode)
   const idleRef = useRef(isIdle)
 
@@ -224,14 +222,6 @@ export default function MiniPlayerBackdropVisualizer({
     scaleContextToDpr: true,
     deferBackingStoreResizeMs: 96,
   })
-
-  useEffect(() => {
-    const media = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const sync = () => setIsReducedMotion(media.matches)
-    sync()
-    media.addEventListener('change', sync)
-    return () => media.removeEventListener('change', sync)
-  }, [])
 
   useEffect(() => {
     layoutModeRef.current = layoutMode
@@ -278,12 +268,12 @@ export default function MiniPlayerBackdropVisualizer({
   }, [renderProfile])
 
   const visualizerStyle = useMemo(() => {
-    const opacity = resolveOpacity(renderMode, layoutMode, isIdle, renderProfile)
+    const opacity = resolveOpacity(mode, layoutMode, isIdle, renderProfile)
     return {
       '--mini-visualizer-opacity': opacity.toFixed(3),
       '--mini-visualizer-blend': renderProfile.blendMode,
     } as CSSProperties
-  }, [isIdle, layoutMode, renderMode, renderProfile])
+  }, [isIdle, layoutMode, mode, renderProfile])
 
   const stopAnimationLoop = useCallback(() => {
     if (animationRef.current !== null) {
@@ -304,8 +294,8 @@ export default function MiniPlayerBackdropVisualizer({
   }, [])
 
   useEffect(() => {
-    modeRef.current = renderMode
-    if (renderMode === 'off') {
+    modeRef.current = mode
+    if (mode === 'off') {
       pendingLeftChunksRef.current = []
       pendingMonoChunksRef.current = []
       spectrumDataRef.current = null
@@ -325,12 +315,13 @@ export default function MiniPlayerBackdropVisualizer({
     }
 
     scheduleNextFrame()
-  }, [renderMode, scheduleNextFrame, stopAnimationLoop])
+  }, [mode, scheduleNextFrame, stopAnimationLoop])
 
   useEffect(() => {
     if (!isNativeAvailable()) return
 
     const unsubscribe = window.electronAPI.miniPlayer.onVisualizerChunk((chunk) => {
+      console.log('[DEBUG] chunk received', modeRef.current)
       sampleRateRef.current = Math.max(1, chunk.sampleRate)
       pitchLockRef.current = chunk.pitchLock
       const rawUnderfillEnabled = (chunk as { oscilloscopeUnderfillEnabled?: unknown }).oscilloscopeUnderfillEnabled
@@ -339,6 +330,9 @@ export default function MiniPlayerBackdropVisualizer({
       const activeMode = modeRef.current
 
       if (chunk.reset) {
+        if (activeMode === 'oscilloscope') {
+          console.log('[DEBUG] chunk.reset === true (oscilloscope)', Date.now())
+        }
         pendingLeftChunksRef.current = []
         pendingMonoChunksRef.current = []
         spectrumDataRef.current = null
@@ -558,6 +552,8 @@ export default function MiniPlayerBackdropVisualizer({
         samplesReceivedRef.current += chunk.length
       }
 
+      console.log('[DEBUG] drawOscilloscope samplesReceivedRef.current =', samplesReceivedRef.current)
+
       const pitchLock = pitchLockRef.current
       if (pitchLock && samplesReceivedRef.current < OSCILLOSCOPE_WARMUP_SAMPLES) return
 
@@ -731,7 +727,7 @@ export default function MiniPlayerBackdropVisualizer({
     <div
       ref={containerRef}
       className={`mini-player-backdrop-visualizer ${isIdle ? 'is-idle' : ''}`.trim()}
-      data-mode={renderMode}
+      data-mode={mode}
       style={visualizerStyle}
       aria-hidden="true"
     >

--- a/src/renderer/components/settings/ArtistSplitExceptionsSettings.tsx
+++ b/src/renderer/components/settings/ArtistSplitExceptionsSettings.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+import { useLibraryStore } from '../../stores/libraryStore'
+
+export default function ArtistSplitExceptionsSettings() {
+  const artistSplitExceptions = useLibraryStore((state) => state.artistSplitExceptions)
+  const loadArtistSplitExceptions = useLibraryStore((state) => state.loadArtistSplitExceptions)
+  const addArtistSplitException = useLibraryStore((state) => state.addArtistSplitException)
+  const removeArtistSplitException = useLibraryStore((state) => state.removeArtistSplitException)
+  const restartConfirmation = useLibraryStore((state) => state.artistSplitExceptionsRestartConfirmation)
+  const setArtistSplitExceptionsRestartConfirmation = useLibraryStore((state) => state.setArtistSplitExceptionsRestartConfirmation)
+
+  const [nameInput, setNameInput] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    void loadArtistSplitExceptions()
+  }, [loadArtistSplitExceptions])
+
+  // Auto-clear restart confirmation
+  useEffect(() => {
+    if (!restartConfirmation) return
+    const id = window.setTimeout(() => setArtistSplitExceptionsRestartConfirmation(''), 3200)
+    return () => window.clearTimeout(id)
+  }, [restartConfirmation, setArtistSplitExceptionsRestartConfirmation])
+
+  const handleAdd = async () => {
+    const trimmed = nameInput.trim()
+    if (!trimmed || isSubmitting) return
+    setIsSubmitting(true)
+    try {
+      await addArtistSplitException(trimmed)
+      setNameInput('')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="settings-card">
+      <div className="settings-card-label">Artist Split Exceptions</div>
+      <div className="settings-grid">
+        <div className="settings-field">
+          <span className="settings-field-label">Exceptions</span>
+          <div className="settings-inline-row">
+            <input
+              className="settings-select settings-inline-input"
+              type="text"
+              placeholder="e.g. Tyler, The Creator"
+              value={nameInput}
+              onChange={(event) => setNameInput(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key !== 'Enter') return
+                event.preventDefault()
+                void handleAdd()
+              }}
+            />
+            <button
+              type="button"
+              className="settings-btn settings-btn-primary"
+              onClick={() => void handleAdd()}
+              disabled={!nameInput.trim() || isSubmitting}
+            >
+              Add
+            </button>
+          </div>
+          <p className="settings-note">
+            Full artist credits listed here are never split into separate collaborators
+            (e.g. &quot;Tyler, The Creator&quot;, &quot;Earth, Wind &amp; Fire&quot;).
+          </p>
+          {artistSplitExceptions.length > 0 && (
+            <div className="settings-artist-split-exception-list">
+              {artistSplitExceptions.map((name) => (
+                <div key={name} className="settings-inline-row">
+                  <span className="settings-chip settings-chip-mono settings-chip-grow">{name}</span>
+                  <button
+                    type="button"
+                    className="settings-chip settings-chip-danger"
+                    onClick={() => void removeArtistSplitException(name)}
+                    aria-label={`Remove ${name}`}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          <p className="settings-note">
+            Restart Astra after modifying this list for changes to take effect.
+          </p>
+          {restartConfirmation && <p className="settings-note settings-note-success">{restartConfirmation}</p>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/views/GraphView.tsx
+++ b/src/renderer/components/views/GraphView.tsx
@@ -216,6 +216,7 @@ export default function GraphView() {
   const loadFullTracks = useLibraryStore((state) => state.loadFullTracks)
   const releaseFullTracks = useLibraryStore((state) => state.releaseFullTracks)
   const selectArtist = useLibraryStore((state) => state.selectArtist)
+  const artistSplitExceptions = useLibraryStore((state) => state.artistSplitExceptions)
 
   const mode = useGraphStore((state) => state.mode)
   const focusedArtistKey = useGraphStore((state) => state.focusedArtistKey)
@@ -318,8 +319,8 @@ export default function GraphView() {
   }, [])
 
   const graph = useMemo(
-    () => buildArtistGraph(graphTracks),
-    [graphTracks]
+    () => buildArtistGraph(graphTracks, artistSplitExceptions),
+    [graphTracks, artistSplitExceptions]
   )
   const graphIndex = useMemo(
     () => indexArtistGraph(graph),

--- a/src/renderer/components/views/HomeView.tsx
+++ b/src/renderer/components/views/HomeView.tsx
@@ -728,14 +728,15 @@ function getHomeRecentLimits(viewportWidth: number): HomeRecentLimits {
   return HOME_RECENT_LIMITS_SMALL
 }
 
-function getPrimaryContributor(rawArtist: string): string {
-  const contributors = splitCollaborators(rawArtist)
+function getPrimaryContributor(rawArtist: string, exceptions: string[] = []): string {
+  const contributors = splitCollaborators(rawArtist, exceptions)
   return contributors[0] ?? 'Unknown Artist'
 }
 
 function getRecentArtistCandidate(
   track: Pick<HomeTrack, 'artist' | 'artist_names' | 'album_artist' | 'album_artist_names'>,
-  mode: LibraryArtistBrowseMode
+  mode: LibraryArtistBrowseMode,
+  exceptions: string[] = []
 ): string {
   const albumArtist = (track.album_artist ?? '').replace(/\s+/g, ' ').trim()
   if (mode === 'strict') {
@@ -745,7 +746,7 @@ function getRecentArtistCandidate(
   const albumArtistKey = normalizeKey(albumArtist)
 
   if (albumArtist && !GENERIC_ARTIST_KEYS.has(albumArtistKey)) {
-    return getPrimaryContributor(albumArtist)
+    return getPrimaryContributor(albumArtist, exceptions)
   }
 
   if (track.artist_names.length > 0) {
@@ -755,7 +756,7 @@ function getRecentArtistCandidate(
     return track.album_artist_names[0]
   }
 
-  return getPrimaryContributor(track.artist)
+  return getPrimaryContributor(track.artist, exceptions)
 }
 
 function formatHomeClockTime(date: Date): string {
@@ -779,6 +780,7 @@ export default function HomeView() {
   const albums = useLibraryStore((s) => s.albums as HomeAlbum[])
   const artists = useLibraryStore((s) => s.artists as HomeArtist[])
   const artistBrowseMode = useLibraryStore((s) => s.artistBrowseMode)
+  const artistSplitExceptions = useLibraryStore((s) => s.artistSplitExceptions)
   const recentlyPlayedPaths = useLibraryStore((s) => s.recentlyPlayedPaths)
   const favoriteTrackPaths = useLibraryStore((s) => s.favoriteTrackPaths)
   const trackCacheVersion = useLibraryStore((s) => s.trackCacheVersion)
@@ -1041,7 +1043,7 @@ export default function HomeView() {
     const uniqueArtists: HomeArtist[] = []
 
     for (const track of recentlyPlayed) {
-      const candidateArtist = getRecentArtistCandidate(track, artistBrowseMode) || 'Unknown Artist'
+      const candidateArtist = getRecentArtistCandidate(track, artistBrowseMode, artistSplitExceptions) || 'Unknown Artist'
       const key = normalizeKey(candidateArtist)
       if (!key || seenArtistKeys.has(key)) continue
       seenArtistKeys.add(key)
@@ -1059,7 +1061,7 @@ export default function HomeView() {
     }
 
     return uniqueArtists
-  }, [artistBrowseMode, recentlyPlayed, artistByKey, recentLimits])
+  }, [artistBrowseMode, recentlyPlayed, artistByKey, recentLimits, artistSplitExceptions])
 
   const recentAlbums = useMemo(() => {
     const seenAlbumIdentityKeys = new Set<string>()

--- a/src/renderer/components/views/LibraryView.tsx
+++ b/src/renderer/components/views/LibraryView.tsx
@@ -13,6 +13,7 @@ import { compareAlbumsByYearDescending } from '../../utils/albumYearSort'
 import { partitionArtistDiscography } from '../../utils/artistDiscography'
 import { formatCompactTotalTrackDuration } from '../../utils/collectionDuration'
 import { matchesFuzzyFields } from '../../utils/fuzzySearch'
+import { matchesTrackSearchQuery } from '../../../shared/library/trackSearch'
 import { runViewTransition } from '../../utils/viewTransitions'
 import { compareTrackPlayCounts } from '../../utils/trackPlayCountSort'
 import { getLibraryTabTransitionScopeClasses } from '../../utils/libraryTabMotion'
@@ -25,6 +26,7 @@ import {
   type LibraryYearGroup
 } from '../../utils/libraryYears'
 import TrackList, { type TrackListSortKey, type TrackListViewportAPI } from '../library/TrackList'
+import SearchControl from '../library/SearchControl'
 import AlbumArtwork from '../library/AlbumArtwork'
 import QueueSplitButton from '../queue/QueueSplitButton'
 import AlbumGrid, { type AlbumGridViewportAPI } from '../library/AlbumGrid'
@@ -156,12 +158,13 @@ function compareAlbumSequence(
 
 function resolveBrowseArtistForTrack(
   track: { artist: string; artist_names?: string[] | null; album_artist: string | null; album_artist_names?: string[] | null },
-  mode: LibraryArtistBrowseMode
+  mode: LibraryArtistBrowseMode,
+  exceptions: string[] = []
 ): string {
   const normalizedAlbumArtist = track.album_artist?.trim() ?? ''
   if (normalizedAlbumArtist) {
     if (mode === 'strict') return normalizedAlbumArtist
-    const albumArtistContributors = splitCollaborators(normalizedAlbumArtist)
+    const albumArtistContributors = splitCollaborators(normalizedAlbumArtist, exceptions)
     return albumArtistContributors[0] ?? normalizedAlbumArtist
   }
 
@@ -169,17 +172,8 @@ function resolveBrowseArtistForTrack(
   if (mode === 'strict') return normalizedArtist || 'Unknown Artist'
   if (track.artist_names && track.artist_names.length > 0) return track.artist_names[0]
   if (track.album_artist_names && track.album_artist_names.length > 0) return track.album_artist_names[0]
-  const artistContributors = splitCollaborators(normalizedArtist)
+  const artistContributors = splitCollaborators(normalizedArtist, exceptions)
   return artistContributors[0] ?? (normalizedArtist || 'Unknown Artist')
-}
-
-function trackMatchesLibraryQuery(
-  track: { title: string },
-  query: string
-): boolean {
-  return matchesFuzzyFields(query, [
-    { value: track.title, weight: 1.5 }
-  ])
 }
 
 export default function LibraryView() {
@@ -194,6 +188,7 @@ export default function LibraryView() {
   const artists = useLibraryStore((state) => state.artists)
   const genres = useLibraryStore((state) => state.genres)
   const folders = useLibraryStore((state) => state.folders)
+  const artistSplitExceptions = useLibraryStore((state) => state.artistSplitExceptions)
   const viewMode = useLibraryStore((state) => state.viewMode)
   const selectedAlbum = useLibraryStore((state) => state.selectedAlbum)
   const selectedArtist = useLibraryStore((state) => state.selectedArtist)
@@ -751,7 +746,7 @@ export default function LibraryView() {
 
   const displayTracks = useMemo(() => {
     if (!hasSearchQuery) return queueSeedSortedTracks
-    return queueSeedSortedTracks.filter((track) => trackMatchesLibraryQuery(track, trimmedSearchQuery))
+    return queueSeedSortedTracks.filter((track) => matchesTrackSearchQuery(track, trimmedSearchQuery))
   }, [hasSearchQuery, trimmedSearchQuery, queueSeedSortedTracks])
 
   const sourceFilteredAlbumIdentityKeys = useMemo(() => {
@@ -820,14 +815,14 @@ export default function LibraryView() {
     for (const track of sourceFilteredTracks) {
       const parsedArtistNames = track.artist_names.length > 0 ? track.artist_names : track.album_artist_names
       if (artistBrowseMode === 'canonical' && parsedArtistNames.length > 0) {
-        const browseArtistKey = normalizeKey(resolveBrowseArtistForTrack(track, artistBrowseMode))
+        const browseArtistKey = normalizeKey(resolveBrowseArtistForTrack(track, artistBrowseMode, artistSplitExceptions))
         if (browseArtistKey) keys.add(browseArtistKey)
         for (const artistName of parsedArtistNames) {
           const normalizedArtistKey = normalizeKey(artistName)
           if (normalizedArtistKey) keys.add(normalizedArtistKey)
         }
       } else {
-        const browseArtist = resolveBrowseArtistForTrack(track, artistBrowseMode)
+        const browseArtist = resolveBrowseArtistForTrack(track, artistBrowseMode, artistSplitExceptions)
         const normalizedArtistKey = normalizeKey(browseArtist)
         if (normalizedArtistKey) {
           keys.add(normalizedArtistKey)
@@ -835,7 +830,7 @@ export default function LibraryView() {
       }
     }
     return keys
-  }, [artistBrowseMode, selectedSourceFilters.size, shouldShowSourceFilters, hasHiddenFolders, sourceFilteredTracks])
+  }, [artistBrowseMode, selectedSourceFilters.size, shouldShowSourceFilters, hasHiddenFolders, sourceFilteredTracks, artistSplitExceptions])
 
   const sourceFilteredPrimaryArtistKeys = useMemo(() => {
     if (artistBrowseMode !== 'canonical') return null
@@ -843,11 +838,11 @@ export default function LibraryView() {
 
     const keys = new Set<string>()
     for (const track of sourceFilteredTracks) {
-      const browseArtistKey = normalizeKey(resolveBrowseArtistForTrack(track, artistBrowseMode))
+      const browseArtistKey = normalizeKey(resolveBrowseArtistForTrack(track, artistBrowseMode, artistSplitExceptions))
       if (browseArtistKey) keys.add(browseArtistKey)
     }
     return keys
-  }, [artistBrowseMode, selectedSourceFilters.size, shouldShowSourceFilters, hasHiddenFolders, sourceFilteredTracks])
+  }, [artistBrowseMode, selectedSourceFilters.size, shouldShowSourceFilters, hasHiddenFolders, sourceFilteredTracks, artistSplitExceptions])
 
   const visibleArtists = useMemo(() => {
     if (!sourceFilteredArtistKeys) return artists
@@ -935,7 +930,7 @@ export default function LibraryView() {
     for (const track of sourceFilteredTracks) {
       const identityKey = track.album_identity_key || buildAlbumIdentityKeyFromTrack(track)
       const identityArtist = getAlbumIdentityArtist(track)
-      const browseArtist = resolveBrowseArtistForTrack(track, artistBrowseMode)
+      const browseArtist = resolveBrowseArtistForTrack(track, artistBrowseMode, artistSplitExceptions)
       const fallbackKey = buildAlbumKey(track.album, identityArtist)
       const match = albumByIdentityKey.get(identityKey) ?? albumByKey.get(fallbackKey)
 
@@ -965,7 +960,7 @@ export default function LibraryView() {
           identity_key: identityKey,
           album: normalizedAlbumName,
           artist: identityArtist || UNKNOWN_ARTIST_NAME,
-          primary_artist: resolveBrowseArtistForTrack(track, 'canonical'),
+          primary_artist: resolveBrowseArtistForTrack(track, 'canonical', artistSplitExceptions),
           year: track.year,
           artwork_hash: track.artwork_hash,
           track_count: 1,
@@ -1006,7 +1001,7 @@ export default function LibraryView() {
       primaryArtistSingles: sections.singles,
       featuredArtistAlbums: sections.featured
     }
-  }, [albumByIdentityKey, albumByKey, albums, artistBrowseMode, selectedArtist, sourceFilteredTracks])
+  }, [albumByIdentityKey, albumByKey, albums, artistBrowseMode, selectedArtist, sourceFilteredTracks, artistSplitExceptions])
 
   const selectedAlbumRecord = useMemo(() => {
     if (!selectedAlbum) return null
@@ -1657,34 +1652,7 @@ export default function LibraryView() {
   }
 
   const renderSearchControl = () => (
-    <div className="search-container">
-      <span className="search-icon" aria-hidden="true">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <circle cx="11" cy="11" r="7" />
-          <path d="m20 20-3.5-3.5" />
-        </svg>
-      </span>
-      <input
-        type="text"
-        className="search-input"
-        data-shortcut-search="true"
-        placeholder={searchPlaceholder}
-        aria-label={searchPlaceholder}
-        value={searchQuery}
-        onChange={(event) => setSearchQuery(event.target.value)}
-      />
-      {searchQuery.length > 0 && (
-        <button
-          type="button"
-          className="search-clear-btn"
-          aria-label="Clear search"
-          title="Clear search"
-          onClick={() => setSearchQuery('')}
-        >
-          ×
-        </button>
-      )}
-    </div>
+    <SearchControl value={searchQuery} onChange={setSearchQuery} placeholder={searchPlaceholder} />
   )
 
   const renderScanForChangesControl = () => (

--- a/src/renderer/components/views/PlaylistView.tsx
+++ b/src/renderer/components/views/PlaylistView.tsx
@@ -17,6 +17,8 @@ import { compareTrackPlayCounts } from '../../utils/trackPlayCountSort'
 import { getDetailHeaderCollapseDistance, resolveDetailHeaderCollapsed } from '../../utils/detailHeaderScroll'
 import AlbumArtwork from '../library/AlbumArtwork'
 import TrackList, { type TrackListSortKey, type TrackListSortState } from '../library/TrackList'
+import SearchControl from '../library/SearchControl'
+import { matchesTrackSearchQuery } from '../../../shared/library/trackSearch'
 import CreatePlaylistModal from '../playlists/CreatePlaylistModal'
 import DynamicPlaylistRuleEditor from '../playlists/DynamicPlaylistRuleEditor'
 import PlaylistCover from '../playlists/PlaylistCover'
@@ -310,6 +312,7 @@ export default function PlaylistView() {
     [favoriteTracks, playlists]
   )
 
+  const [searchQuery, setSearchQuery] = useState('')
   const [isRenaming, setIsRenaming] = useState(false)
   const [renameValue, setRenameValue] = useState('')
   const [isUpdatingCover, setIsUpdatingCover] = useState(false)
@@ -481,14 +484,26 @@ export default function PlaylistView() {
     return indexedRows.map(({ row }) => row)
   }, [playlistDisplayRows, sortState, trackRatings])
 
-  const displayTracks = useMemo(() => displayRows.map((row) => row.track), [displayRows])
-  const displayPlaylistEntryIds = useMemo(() => displayRows.map((row) => row.entryId), [displayRows])
-  const displayTrackNumbers = useMemo(() => displayRows.map((row) => row.defaultNumber), [displayRows])
-  const displayTrackInstanceKeys = useMemo(() => displayRows.map((row) => row.instanceKey), [displayRows])
+  const trimmedSearchQuery = searchQuery.trim()
+
+  // Full, sorted (not search-filtered) tracks — the queue-seed derivations below stay
+  // based on this so playing/shuffling while a search is active still uses the whole
+  // playlist, matching LibraryView's search-only-filters-display convention.
+  const allDisplayTracks = useMemo(() => displayRows.map((row) => row.track), [displayRows])
+
+  const searchFilteredRows = useMemo(() => {
+    if (!trimmedSearchQuery) return displayRows
+    return displayRows.filter((row) => matchesTrackSearchQuery(row.track, trimmedSearchQuery))
+  }, [displayRows, trimmedSearchQuery])
+
+  const displayTracks = useMemo(() => searchFilteredRows.map((row) => row.track), [searchFilteredRows])
+  const displayPlaylistEntryIds = useMemo(() => searchFilteredRows.map((row) => row.entryId), [searchFilteredRows])
+  const displayTrackNumbers = useMemo(() => searchFilteredRows.map((row) => row.defaultNumber), [searchFilteredRows])
+  const displayTrackInstanceKeys = useMemo(() => searchFilteredRows.map((row) => row.instanceKey), [searchFilteredRows])
 
   const displayPlayableTracks = useMemo(
-    () => displayTracks.filter((track) => !isMissingPlaylistDisplayTrack(track)),
-    [displayTracks]
+    () => allDisplayTracks.filter((track) => !isMissingPlaylistDisplayTrack(track)),
+    [allDisplayTracks]
   )
   const displayQueueSeedIndexes = useMemo(
     () => buildPlayableOccurrenceIndexes(displayRows, (row) => !isMissingPlaylistDisplayTrack(row.track)),
@@ -1223,6 +1238,7 @@ export default function PlaylistView() {
               </svg>
             </button>
           )}
+          <SearchControl value={searchQuery} onChange={setSearchQuery} placeholder="Search playlist..." />
           <div className="playlist-header-menu-wrap" ref={moreMenuRef}>
             <button
               type="button"
@@ -1391,8 +1407,14 @@ export default function PlaylistView() {
               </button>
             </div>
           </>
-        ) : displayTracks.length > 0 || playlistMissingCount > 0 ? (
+        ) : allDisplayTracks.length > 0 || playlistMissingCount > 0 ? (
           <>
+            {trimmedSearchQuery && displayTracks.length === 0 && (
+              <div className="library-empty">
+                <p>No matching tracks</p>
+                <p className="empty-hint">No tracks in this playlist match your search.</p>
+              </div>
+            )}
             {displayTracks.length > 0 && (
               <TrackList
                 tracks={displayTracks}
@@ -1416,6 +1438,7 @@ export default function PlaylistView() {
                     : null
                 }
                 onJumpToTrackRequestConsumed={clearPlaylistTrackRevealRequest}
+                searchQuery={trimmedSearchQuery}
               />
             )}
           </>

--- a/src/renderer/components/views/SettingsView.tsx
+++ b/src/renderer/components/views/SettingsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import FolderSettings from '../settings/FolderSettings'
+import ArtistSplitExceptionsSettings from '../settings/ArtistSplitExceptionsSettings'
 import AudioOutputSelect from '../settings/AudioOutputSelect'
 import ChannelRoutingPanel from '../settings/ChannelRoutingPanel'
 import DelayCompensationPanel from '../settings/DelayCompensationPanel'
@@ -11,14 +12,23 @@ import KeybindSettings from '../settings/KeybindSettings'
 import SettingsTransferWizard from '../settings/SettingsTransferWizard'
 import ImportedListeningDataCard from '../settings/ImportedListeningDataCard'
 import SettingsSegmentedControl, { type SettingsSegmentedOption } from '../settings/SettingsSegmentedControl'
+import { AlbumGridScalePreview, ArtistGridScalePreview } from '../library/GridScalePreview'
 import { renderPairingQrSvg } from '../../utils/pairingQr'
 import { usePresence } from '../../hooks/usePresence'
 import { useLibraryStore } from '../../stores/libraryStore'
 import { usePlayerStore } from '../../stores/playerStore'
 import {
+  DEFAULT_ALBUM_GRID_SCALE_PERCENT,
+  DEFAULT_ARTIST_GRID_SCALE_PERCENT,
   DEFAULT_UI_SCALE_PERCENT,
   DEFAULT_JUMP_TO_PLAYING_DESTINATION,
+  ALBUM_GRID_SCALE_STEP_PERCENT,
+  ARTIST_GRID_SCALE_STEP_PERCENT,
+  MAX_ALBUM_GRID_SCALE_PERCENT,
+  MAX_ARTIST_GRID_SCALE_PERCENT,
   MAX_UI_SCALE_PERCENT,
+  MIN_ALBUM_GRID_SCALE_PERCENT,
+  MIN_ARTIST_GRID_SCALE_PERCENT,
   MIN_UI_SCALE_PERCENT,
   UI_SCALE_STEP_PERCENT,
   useUIStore,
@@ -120,6 +130,9 @@ const NATIVE_SAMPLE_FORMAT_LABELS: Record<string, string> = {
 
 const NORMALIZATION_TARGET_MIN_LUFS = -30
 const NORMALIZATION_TARGET_MAX_LUFS = 0
+
+const FADE_DURATION_MIN_MS = 200
+const FADE_DURATION_MAX_MS = 15000
 
 const CUSTOM_SCROBBLE_PROTOCOLS: LastFmScrobbleProtocol[] = ['lastfm2', 'audioscrobbler', 'listenbrainz']
 
@@ -319,6 +332,19 @@ function parseNormalizationTargetLufsInput(input: string): number | null {
   return Math.round(parsed * 10) / 10
 }
 
+function formatFadeDurationMs(value: number): string {
+  return String(Math.round(value))
+}
+
+function parseFadeDurationMsInput(input: string): number | null {
+  const trimmed = input.trim()
+  if (!/^\d+$/.test(trimmed)) return null
+  const parsed = Number(trimmed)
+  if (!Number.isInteger(parsed)) return null
+  if (parsed < FADE_DURATION_MIN_MS || parsed > FADE_DURATION_MAX_MS) return null
+  return parsed
+}
+
 function readDeveloperSectionVisibilityPreference(): boolean {
   try {
     return localStorage.getItem(DEVELOPER_SETTINGS_VISIBILITY_STORAGE_KEY) === '1'
@@ -393,6 +419,16 @@ export default function SettingsView() {
   const setNormalizationEnabled = useAudioSettingsStore((state) => state.setNormalizationEnabled)
   const normalizationTargetLufs = useAudioSettingsStore((state) => state.normalizationTargetLufs)
   const setNormalizationTargetLufs = useAudioSettingsStore((state) => state.setNormalizationTargetLufs)
+  const fadeEnabled = useAudioSettingsStore((state) => state.fadeEnabled)
+  const setFadeEnabled = useAudioSettingsStore((state) => state.setFadeEnabled)
+  const fadeInDurationMs = useAudioSettingsStore((state) => state.fadeInDurationMs)
+  const setFadeInDurationMs = useAudioSettingsStore((state) => state.setFadeInDurationMs)
+  const fadeOutDurationMs = useAudioSettingsStore((state) => state.fadeOutDurationMs)
+  const setFadeOutDurationMs = useAudioSettingsStore((state) => state.setFadeOutDurationMs)
+  const crossfadeEnabled = useAudioSettingsStore((state) => state.crossfadeEnabled)
+  const setCrossfadeEnabled = useAudioSettingsStore((state) => state.setCrossfadeEnabled)
+  const crossfadeDurationMs = useAudioSettingsStore((state) => state.crossfadeDurationMs)
+  const setCrossfadeDurationMs = useAudioSettingsStore((state) => state.setCrossfadeDurationMs)
   const playbackOutputMode = useAudioSettingsStore((state) => state.playbackOutputMode)
   const setPlaybackOutputMode = useAudioSettingsStore((state) => state.setPlaybackOutputMode)
   const disableGaplessPrebufferDev = useAudioSettingsStore((state) => state.disableGaplessPrebufferDev)
@@ -531,6 +567,9 @@ export default function SettingsView() {
   const [normalizationDisableStep, setNormalizationDisableStep] = useState<NormalizationDisableStep>(null)
   const [normalizationTargetInput, setNormalizationTargetInput] = useState(() => formatNormalizationTargetLufs(normalizationTargetLufs))
   const [normalizationTargetError, setNormalizationTargetError] = useState('')
+  const [fadeInDurationInput, setFadeInDurationInput] = useState(() => formatFadeDurationMs(fadeInDurationMs))
+  const [fadeOutDurationInput, setFadeOutDurationInput] = useState(() => formatFadeDurationMs(fadeOutDurationMs))
+  const [crossfadeDurationInput, setCrossfadeDurationInput] = useState(() => formatFadeDurationMs(crossfadeDurationMs))
   const [lyricsTranslationPriorityInput, setLyricsTranslationPriorityInput] = useState(() => (
     lyricsDisplaySettings.translationLanguagePriority.join(', ')
   ))
@@ -545,6 +584,14 @@ export default function SettingsView() {
   const uiScalePercent = useUIStore((state) => state.uiScalePercent)
   const setUIScalePercent = useUIStore((state) => state.setUIScalePercent)
   const resetUIScalePercent = useUIStore((state) => state.resetUIScalePercent)
+  const albumGridScalePercent = useUIStore((state) => state.albumGridScalePercent)
+  const setAlbumGridScalePercent = useUIStore((state) => state.setAlbumGridScalePercent)
+  const resetAlbumGridScalePercent = useUIStore((state) => state.resetAlbumGridScalePercent)
+  const artistGridScalePercent = useUIStore((state) => state.artistGridScalePercent)
+  const setArtistGridScalePercent = useUIStore((state) => state.setArtistGridScalePercent)
+  const resetArtistGridScalePercent = useUIStore((state) => state.resetArtistGridScalePercent)
+  const showAlbumGridYear = useLibraryStore((state) => state.showAlbumGridYear)
+  const setShowAlbumGridYear = useLibraryStore((state) => state.setShowAlbumGridYear)
   const homeGreetingTextMode = useUIStore((state) => state.homeGreetingTextMode)
   const setHomeGreetingTextMode = useUIStore((state) => state.setHomeGreetingTextMode)
   const transportInfoLineMode = useUIStore((state) => state.transportInfoLineMode)
@@ -1490,6 +1537,39 @@ export default function SettingsView() {
     setNormalizationTargetInput(formatNormalizationTargetLufs(DEFAULT_NORMALIZATION_TARGET_LUFS))
   }
 
+  const commitFadeInDuration = () => {
+    if (bitPerfectModeActive) return
+    const parsed = parseFadeDurationMsInput(fadeInDurationInput)
+    if (parsed == null) {
+      setFadeInDurationInput(formatFadeDurationMs(fadeInDurationMs))
+      return
+    }
+    setFadeInDurationMs(parsed)
+    setFadeInDurationInput(formatFadeDurationMs(parsed))
+  }
+
+  const commitFadeOutDuration = () => {
+    if (bitPerfectModeActive) return
+    const parsed = parseFadeDurationMsInput(fadeOutDurationInput)
+    if (parsed == null) {
+      setFadeOutDurationInput(formatFadeDurationMs(fadeOutDurationMs))
+      return
+    }
+    setFadeOutDurationMs(parsed)
+    setFadeOutDurationInput(formatFadeDurationMs(parsed))
+  }
+
+  const commitCrossfadeDuration = () => {
+    if (bitPerfectModeActive) return
+    const parsed = parseFadeDurationMsInput(crossfadeDurationInput)
+    if (parsed == null) {
+      setCrossfadeDurationInput(formatFadeDurationMs(crossfadeDurationMs))
+      return
+    }
+    setCrossfadeDurationMs(parsed)
+    setCrossfadeDurationInput(formatFadeDurationMs(parsed))
+  }
+
   const replayGainSelectorValue: ReplayGainSelectorValue = replayGainScanEnabled
     ? replayGainMode
     : 'disabled'
@@ -1867,6 +1947,7 @@ export default function SettingsView() {
                   </div>
                 </div>
               </div>
+              <ArtistSplitExceptionsSettings />
               <div className="settings-card">
                 <div className="settings-card-label">Track Ratings</div>
                 <div className="settings-grid">
@@ -1926,6 +2007,79 @@ export default function SettingsView() {
                       {showTracklistPlayCount ? 'Enabled' : 'Disabled'}
                     </button>
                   </div>
+                </div>
+              </div>
+              <div className="settings-card">
+                <div className="settings-card-label">Album Grid</div>
+                <AlbumGridScalePreview />
+                <div className="settings-grid">
+                  <label className="settings-field">
+                    <span className="settings-field-label">Card Size</span>
+                    <div className="settings-scale-row">
+                      <input
+                        className="settings-scale-slider"
+                        type="range"
+                        min={MIN_ALBUM_GRID_SCALE_PERCENT}
+                        max={MAX_ALBUM_GRID_SCALE_PERCENT}
+                        step={ALBUM_GRID_SCALE_STEP_PERCENT}
+                        value={albumGridScalePercent}
+                        onChange={(event) => setAlbumGridScalePercent(Number(event.target.value))}
+                        aria-label="Album grid card size"
+                      />
+                      <span className="settings-chip settings-chip-mono settings-scale-value">
+                        {albumGridScalePercent}%
+                      </span>
+                      <button
+                        type="button"
+                        className="settings-chip settings-chip-mono settings-chip-danger"
+                        onClick={resetAlbumGridScalePercent}
+                        disabled={albumGridScalePercent === DEFAULT_ALBUM_GRID_SCALE_PERCENT}
+                      >
+                        RESET
+                      </button>
+                    </div>
+                  </label>
+                  <div className="settings-field settings-field-inline">
+                    <span className="settings-field-label">Year</span>
+                    <button
+                      className={`settings-toggle ${showAlbumGridYear ? 'active' : ''}`}
+                      onClick={() => setShowAlbumGridYear(!showAlbumGridYear)}
+                    >
+                      {showAlbumGridYear ? 'Enabled' : 'Disabled'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div className="settings-card">
+                <div className="settings-card-label">Artist Grid</div>
+                <ArtistGridScalePreview />
+                <div className="settings-grid">
+                  <label className="settings-field">
+                    <span className="settings-field-label">Card Size</span>
+                    <div className="settings-scale-row">
+                      <input
+                        className="settings-scale-slider"
+                        type="range"
+                        min={MIN_ARTIST_GRID_SCALE_PERCENT}
+                        max={MAX_ARTIST_GRID_SCALE_PERCENT}
+                        step={ARTIST_GRID_SCALE_STEP_PERCENT}
+                        value={artistGridScalePercent}
+                        onChange={(event) => setArtistGridScalePercent(Number(event.target.value))}
+                        aria-label="Artist grid card size"
+                      />
+                      <span className="settings-chip settings-chip-mono settings-scale-value">
+                        {artistGridScalePercent}%
+                      </span>
+                      <button
+                        type="button"
+                        className="settings-chip settings-chip-mono settings-chip-danger"
+                        onClick={resetArtistGridScalePercent}
+                        disabled={artistGridScalePercent === DEFAULT_ARTIST_GRID_SCALE_PERCENT}
+                      >
+                        RESET
+                      </button>
+                    </div>
+                  </label>
                 </div>
               </div>
             </div>
@@ -2143,7 +2297,110 @@ export default function SettingsView() {
                   </p>
                 )}
               </div>
+              <div className="settings-card">
+                <div className="settings-card-label">Fade</div>
+                <div className="settings-grid">
+                  <div className="settings-field settings-field-inline">
+                    <span className="settings-field-label">Fade In/Out</span>
+                    <button
+                      type="button"
+                      className={`settings-toggle ${fadeEnabled ? 'active' : ''}`}
+                      onClick={() => setFadeEnabled(!fadeEnabled)}
+                      disabled={bitPerfectModeActive}
+                      title={bitPerfectModeActive ? BIT_PERFECT_DSP_DISABLED_MESSAGE : undefined}
+                    >
+                      {fadeEnabled ? 'Enabled' : 'Disabled'}
+                    </button>
+                  </div>
+                  <label className="settings-field">
+                    <span className="settings-field-label">Fade In Duration</span>
+                    <div className="settings-inline-row">
+                      <input
+                        className="settings-select settings-inline-input settings-inline-input-compact"
+                        type="number"
+                        min={FADE_DURATION_MIN_MS}
+                        max={FADE_DURATION_MAX_MS}
+                        step={100}
+                        value={fadeInDurationInput}
+                        disabled={!fadeEnabled || bitPerfectModeActive}
+                        title={bitPerfectModeActive ? BIT_PERFECT_DSP_DISABLED_MESSAGE : undefined}
+                        onChange={(event) => setFadeInDurationInput(event.target.value)}
+                        onBlur={commitFadeInDuration}
+                        onKeyDown={(event) => {
+                          if (event.key !== 'Enter') return
+                          event.preventDefault()
+                          commitFadeInDuration()
+                        }}
+                      />
+                      <span className="settings-chip settings-chip-mono">ms</span>
+                    </div>
+                  </label>
+                  <label className="settings-field">
+                    <span className="settings-field-label">Fade Out Duration</span>
+                    <div className="settings-inline-row">
+                      <input
+                        className="settings-select settings-inline-input settings-inline-input-compact"
+                        type="number"
+                        min={FADE_DURATION_MIN_MS}
+                        max={FADE_DURATION_MAX_MS}
+                        step={100}
+                        value={fadeOutDurationInput}
+                        disabled={!fadeEnabled || bitPerfectModeActive}
+                        title={bitPerfectModeActive ? BIT_PERFECT_DSP_DISABLED_MESSAGE : undefined}
+                        onChange={(event) => setFadeOutDurationInput(event.target.value)}
+                        onBlur={commitFadeOutDuration}
+                        onKeyDown={(event) => {
+                          if (event.key !== 'Enter') return
+                          event.preventDefault()
+                          commitFadeOutDuration()
+                        }}
+                      />
+                      <span className="settings-chip settings-chip-mono">ms</span>
+                    </div>
+                  </label>
+                  <div className="settings-field settings-field-inline">
+                    <span className="settings-field-label">Crossfade</span>
+                    <button
+                      type="button"
+                      className={`settings-toggle ${crossfadeEnabled ? 'active' : ''}`}
+                      onClick={() => setCrossfadeEnabled(!crossfadeEnabled)}
+                      disabled={bitPerfectModeActive}
+                      title={bitPerfectModeActive ? BIT_PERFECT_DSP_DISABLED_MESSAGE : undefined}
+                    >
+                      {crossfadeEnabled ? 'Enabled' : 'Disabled'}
+                    </button>
+                  </div>
+                  <label className="settings-field">
+                    <span className="settings-field-label">Crossfade Duration</span>
+                    <div className="settings-inline-row">
+                      <input
+                        className="settings-select settings-inline-input settings-inline-input-compact"
+                        type="number"
+                        min={FADE_DURATION_MIN_MS}
+                        max={FADE_DURATION_MAX_MS}
+                        step={100}
+                        value={crossfadeDurationInput}
+                        disabled={!crossfadeEnabled || bitPerfectModeActive}
+                        title={bitPerfectModeActive ? BIT_PERFECT_DSP_DISABLED_MESSAGE : undefined}
+                        onChange={(event) => setCrossfadeDurationInput(event.target.value)}
+                        onBlur={commitCrossfadeDuration}
+                        onKeyDown={(event) => {
+                          if (event.key !== 'Enter') return
+                          event.preventDefault()
+                          commitCrossfadeDuration()
+                        }}
+                      />
+                      <span className="settings-chip settings-chip-mono">ms</span>
+                    </div>
+                  </label>
+                </div>
+              </div>
             </div>
+            {bitPerfectModeActive && (
+              <p className="settings-note">
+                {BIT_PERFECT_DSP_DISABLED_MESSAGE}
+              </p>
+            )}
           </section>
             )}
 

--- a/src/renderer/constants/settingsStorageKeys.ts
+++ b/src/renderer/constants/settingsStorageKeys.ts
@@ -14,6 +14,7 @@ export const ARTIST_BROWSE_MODE_STORAGE_KEY = 'astra-library-artist-browse-mode-
 export const TRACKLIST_BPM_KEY_VISIBILITY_STORAGE_KEY = 'astra-library-tracklist-bpm-key-visible-v1'
 export const TRACKLIST_GENRE_VISIBILITY_STORAGE_KEY = 'astra-library-tracklist-genre-visible-v1'
 export const TRACKLIST_ADDED_DATE_VISIBILITY_STORAGE_KEY = 'astra-library-tracklist-added-date-visible-v1'
+export const ALBUM_GRID_YEAR_VISIBILITY_STORAGE_KEY = 'astra-library-album-grid-year-visible-v1'
 export const TRACKLIST_PLAY_COUNT_VISIBILITY_STORAGE_KEY = 'astra-library-tracklist-play-count-visible-v1'
 export const ALBUM_SORT_MODE_STORAGE_KEY = 'astra-library-album-sort-mode-v1'
 export const INCLUDE_SINGLES_IN_ALBUMS_STORAGE_KEY = 'astra-library-include-singles-in-albums-v1'

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -47,6 +47,7 @@ import type {
   ParallaxTimelineState
 } from '../types/parallax'
 import type {
+    LastFmArtistInfoResult,
     LastFmAuthFinishResult,
     LastFmAuthStartResult,
     LastFmCustomProfileInput,
@@ -139,6 +140,7 @@ interface DbTrack {
     track_number: number | null
 	    disc_number: number | null
 	    year: number | null
+	    date: string | null
 	    genre: string | null
 	    genres: string[]
 	    artwork_hash: string | null
@@ -452,6 +454,7 @@ declare global {
             }
             lastFm: {
                 getStatus: () => Promise<LastFmStatus>
+                getArtistInfo: (artistName: string) => Promise<LastFmArtistInfoResult>
                 setEnabled: (enabled: boolean) => Promise<LastFmStatus>
                 createCustomProfile: (input: LastFmCustomProfileInput) => Promise<LastFmStatus>
                 updateCustomProfile: (profileId: string, input: LastFmCustomProfileInput) => Promise<LastFmStatus>
@@ -638,6 +641,9 @@ declare global {
                 getTracks: () => Promise<DbTrack[]>
                 getTracksPage: (request?: LibraryTrackPageRequest) => Promise<LibraryTrackPage>
                 getTracksByPaths: (trackPaths: string[]) => Promise<DbTrack[]>
+                getArtistSplitExceptions: () => Promise<string[]>
+                addArtistSplitException: (name: string) => Promise<boolean>
+                removeArtistSplitException: (name: string) => Promise<boolean>
                 [key: string]: any
             }
         }

--- a/src/renderer/stores/audioSettingsStore.ts
+++ b/src/renderer/stores/audioSettingsStore.ts
@@ -14,7 +14,7 @@ import {
   type SpatialMode,
   type VirtualSpeaker,
 } from '../utils/virtualSpeakerLayout'
-import type { SpatialStatus } from '../audio/AudioEngine'
+import type { FadeSettings, SpatialStatus } from '../audio/AudioEngine'
 import type { NativeAudioCapabilities, PlaybackOutputMode } from '../../types/nativeAudio'
 
 export interface AudioDevice {
@@ -81,6 +81,11 @@ interface AudioSettingsStore {
   normalizationTargetLufs: number
   replayGainScanEnabled: boolean
   replayGainMode: ReplayGainMode
+  fadeEnabled: boolean
+  fadeInDurationMs: number
+  fadeOutDurationMs: number
+  crossfadeEnabled: boolean
+  crossfadeDurationMs: number
 
   delayProfilesByDeviceKey: Record<string, DelayCompensationProfile>
   inputBaselinesByKey: Record<string, InputDelayBaseline>
@@ -111,6 +116,11 @@ interface AudioSettingsStore {
   setNormalizationTargetLufs: (targetLufs: number) => void
   setReplayGainScanEnabled: (enabled: boolean) => Promise<void>
   setReplayGainMode: (mode: ReplayGainMode) => void
+  setFadeEnabled: (enabled: boolean) => void
+  setFadeInDurationMs: (durationMs: number) => void
+  setFadeOutDurationMs: (durationMs: number) => void
+  setCrossfadeEnabled: (enabled: boolean) => void
+  setCrossfadeDurationMs: (durationMs: number) => void
 
   setDelayCompensationEnabled: (enabled: boolean) => Promise<void>
   setDelayCompensationMode: (mode: DelayCompensationMode) => Promise<void>
@@ -137,6 +147,14 @@ const ROUTING_STORAGE_KEY = 'astra-audio-channel-routing-map'
 export const NORMALIZATION_ENABLED_STORAGE_KEY = 'astra-audio-normalization-enabled-v1'
 export const NORMALIZATION_TARGET_STORAGE_KEY = 'astra-audio-normalization-target-lufs-v1'
 export const REPLAYGAIN_MODE_STORAGE_KEY = 'astra-audio-replaygain-mode-v1'
+const FADE_ENABLED_STORAGE_KEY = 'astra-audio-fade-enabled-v1'
+const FADE_IN_DURATION_STORAGE_KEY = 'astra-audio-fade-in-duration-ms-v1'
+const FADE_OUT_DURATION_STORAGE_KEY = 'astra-audio-fade-out-duration-ms-v1'
+const CROSSFADE_ENABLED_STORAGE_KEY = 'astra-audio-crossfade-enabled-v1'
+const CROSSFADE_DURATION_STORAGE_KEY = 'astra-audio-crossfade-duration-ms-v1'
+const DEFAULT_FADE_IN_DURATION_MS = 2000
+const DEFAULT_FADE_OUT_DURATION_MS = 2000
+const DEFAULT_CROSSFADE_DURATION_MS = 3000
 const DEV_DISABLE_GAPLESS_PREBUFFER_STORAGE_KEY = 'astra-dev-disable-gapless-prebuffer-v1'
 const DEV_DISABLE_STANDARD_ANALYSIS_GRAPH_STORAGE_KEY = 'astra-dev-disable-standard-analysis-graph-v1'
 const DELAY_PROFILE_STORAGE_KEY_V1 = 'astra-audio-delay-profiles-v1'
@@ -145,6 +163,16 @@ const OUTPUT_GROUP_PROFILE_KEY_PREFIX = 'group:'
 export const DEFAULT_NORMALIZATION_TARGET_LUFS = audioEngine.targetLufs
 export const BIT_PERFECT_DSP_DISABLED_MESSAGE = 'Bit-perfect mode bypasses all app DSP and uses exclusive/direct device output.'
 const BIT_PERFECT_LINUX_DEVICE_SELECTION_MESSAGE = 'Bit-perfect mode on Linux requires selecting a direct ALSA hardware output device.'
+
+function applyFadeSettingsToEngine(state: FadeSettings): void {
+  audioEngine.setFadeSettings({
+    fadeEnabled: state.fadeEnabled,
+    fadeInDurationMs: state.fadeInDurationMs,
+    fadeOutDurationMs: state.fadeOutDurationMs,
+    crossfadeEnabled: state.crossfadeEnabled,
+    crossfadeDurationMs: state.crossfadeDurationMs,
+  })
+}
 
 const DEFAULT_DELAY_PROFILE: DelayCompensationProfile = {
   enabled: false,
@@ -1049,6 +1077,11 @@ export const useAudioSettingsStore = create<AudioSettingsStore>((set, get) => {
     normalizationTargetLufs: DEFAULT_NORMALIZATION_TARGET_LUFS,
     replayGainScanEnabled: false,
     replayGainMode: 'auto',
+    fadeEnabled: false,
+    fadeInDurationMs: DEFAULT_FADE_IN_DURATION_MS,
+    fadeOutDurationMs: DEFAULT_FADE_OUT_DURATION_MS,
+    crossfadeEnabled: false,
+    crossfadeDurationMs: DEFAULT_CROSSFADE_DURATION_MS,
 
     delayProfilesByDeviceKey: {},
     inputBaselinesByKey: {},
@@ -1413,6 +1446,44 @@ export const useAudioSettingsStore = create<AudioSettingsStore>((set, get) => {
       const normalized = normalizeReplayGainMode(mode)
       set({ replayGainMode: normalized })
       localStorage.setItem(REPLAYGAIN_MODE_STORAGE_KEY, normalized)
+    },
+
+    setFadeEnabled: (enabled: boolean) => {
+      const normalized = Boolean(enabled)
+      set({ fadeEnabled: normalized })
+      localStorage.setItem(FADE_ENABLED_STORAGE_KEY, normalized ? '1' : '0')
+      applyFadeSettingsToEngine(get())
+    },
+
+    setFadeInDurationMs: (durationMs: number) => {
+      if (!Number.isFinite(durationMs)) return
+      const rounded = Math.round(durationMs)
+      set({ fadeInDurationMs: rounded })
+      localStorage.setItem(FADE_IN_DURATION_STORAGE_KEY, String(rounded))
+      applyFadeSettingsToEngine(get())
+    },
+
+    setFadeOutDurationMs: (durationMs: number) => {
+      if (!Number.isFinite(durationMs)) return
+      const rounded = Math.round(durationMs)
+      set({ fadeOutDurationMs: rounded })
+      localStorage.setItem(FADE_OUT_DURATION_STORAGE_KEY, String(rounded))
+      applyFadeSettingsToEngine(get())
+    },
+
+    setCrossfadeEnabled: (enabled: boolean) => {
+      const normalized = Boolean(enabled)
+      set({ crossfadeEnabled: normalized })
+      localStorage.setItem(CROSSFADE_ENABLED_STORAGE_KEY, normalized ? '1' : '0')
+      applyFadeSettingsToEngine(get())
+    },
+
+    setCrossfadeDurationMs: (durationMs: number) => {
+      if (!Number.isFinite(durationMs)) return
+      const rounded = Math.round(durationMs)
+      set({ crossfadeDurationMs: rounded })
+      localStorage.setItem(CROSSFADE_DURATION_STORAGE_KEY, String(rounded))
+      applyFadeSettingsToEngine(get())
     },
 
     setDelayCompensationEnabled: async (enabled: boolean) => {
@@ -1829,6 +1900,11 @@ export const useAudioSettingsStore = create<AudioSettingsStore>((set, get) => {
       localStorage.removeItem(NORMALIZATION_ENABLED_STORAGE_KEY)
       localStorage.removeItem(NORMALIZATION_TARGET_STORAGE_KEY)
       localStorage.removeItem(REPLAYGAIN_MODE_STORAGE_KEY)
+      localStorage.removeItem(FADE_ENABLED_STORAGE_KEY)
+      localStorage.removeItem(FADE_IN_DURATION_STORAGE_KEY)
+      localStorage.removeItem(FADE_OUT_DURATION_STORAGE_KEY)
+      localStorage.removeItem(CROSSFADE_ENABLED_STORAGE_KEY)
+      localStorage.removeItem(CROSSFADE_DURATION_STORAGE_KEY)
       localStorage.removeItem(DEV_DISABLE_GAPLESS_PREBUFFER_STORAGE_KEY)
       localStorage.removeItem(DEV_DISABLE_STANDARD_ANALYSIS_GRAPH_STORAGE_KEY)
       localStorage.removeItem(DELAY_PROFILE_STORAGE_KEY_V1)
@@ -1891,6 +1967,13 @@ export const useAudioSettingsStore = create<AudioSettingsStore>((set, get) => {
       audioEngine.setReplayGainEnabled(false)
       audioEngine.normalizationEnabled = true
       audioEngine.targetLufs = DEFAULT_NORMALIZATION_TARGET_LUFS
+      audioEngine.setFadeSettings({
+        fadeEnabled: false,
+        fadeInDurationMs: DEFAULT_FADE_IN_DURATION_MS,
+        fadeOutDurationMs: DEFAULT_FADE_OUT_DURATION_MS,
+        crossfadeEnabled: false,
+        crossfadeDurationMs: DEFAULT_CROSSFADE_DURATION_MS,
+      })
       audioEngine.setDisableStandardAnalysisGraphDev(false)
       await audioEngine.setPlaybackOutputMode('standard')
 
@@ -1940,6 +2023,11 @@ export const useAudioSettingsStore = create<AudioSettingsStore>((set, get) => {
         normalizationTargetLufs: DEFAULT_NORMALIZATION_TARGET_LUFS,
         replayGainScanEnabled: false,
         replayGainMode: 'auto',
+        fadeEnabled: false,
+        fadeInDurationMs: DEFAULT_FADE_IN_DURATION_MS,
+        fadeOutDurationMs: DEFAULT_FADE_OUT_DURATION_MS,
+        crossfadeEnabled: false,
+        crossfadeDurationMs: DEFAULT_CROSSFADE_DURATION_MS,
         delayProfilesByDeviceKey: {},
         inputBaselinesByKey: {},
         activeDelayProfileKey: 'default',
@@ -1986,6 +2074,33 @@ export const useAudioSettingsStore = create<AudioSettingsStore>((set, get) => {
       audioEngine.setReplayGainEnabled(replayGainEnabled)
       const replayGainMode = normalizeReplayGainMode(localStorage.getItem(REPLAYGAIN_MODE_STORAGE_KEY))
 
+      const savedFadeEnabled = localStorage.getItem(FADE_ENABLED_STORAGE_KEY)
+      const fadeEnabled = savedFadeEnabled == null ? false : savedFadeEnabled === '1'
+      const savedFadeInDurationRaw = localStorage.getItem(FADE_IN_DURATION_STORAGE_KEY)
+      const parsedFadeInDuration = savedFadeInDurationRaw == null ? Number.NaN : Number(savedFadeInDurationRaw)
+      const fadeInDurationMs = Number.isFinite(parsedFadeInDuration)
+        ? Math.round(parsedFadeInDuration)
+        : DEFAULT_FADE_IN_DURATION_MS
+      const savedFadeOutDurationRaw = localStorage.getItem(FADE_OUT_DURATION_STORAGE_KEY)
+      const parsedFadeOutDuration = savedFadeOutDurationRaw == null ? Number.NaN : Number(savedFadeOutDurationRaw)
+      const fadeOutDurationMs = Number.isFinite(parsedFadeOutDuration)
+        ? Math.round(parsedFadeOutDuration)
+        : DEFAULT_FADE_OUT_DURATION_MS
+      const savedCrossfadeEnabled = localStorage.getItem(CROSSFADE_ENABLED_STORAGE_KEY)
+      const crossfadeEnabled = savedCrossfadeEnabled == null ? false : savedCrossfadeEnabled === '1'
+      const savedCrossfadeDurationRaw = localStorage.getItem(CROSSFADE_DURATION_STORAGE_KEY)
+      const parsedCrossfadeDuration = savedCrossfadeDurationRaw == null ? Number.NaN : Number(savedCrossfadeDurationRaw)
+      const crossfadeDurationMs = Number.isFinite(parsedCrossfadeDuration)
+        ? Math.round(parsedCrossfadeDuration)
+        : DEFAULT_CROSSFADE_DURATION_MS
+      audioEngine.setFadeSettings({
+        fadeEnabled,
+        fadeInDurationMs,
+        fadeOutDurationMs,
+        crossfadeEnabled,
+        crossfadeDurationMs,
+      })
+
       const rawDelaySettingsV2 = localStorage.getItem(DELAY_PROFILE_STORAGE_KEY_V2)
       let savedProfiles: Record<string, DelayCompensationProfile> = {}
       let savedInputBaselines: Record<string, InputDelayBaseline> = {}
@@ -2013,7 +2128,12 @@ export const useAudioSettingsStore = create<AudioSettingsStore>((set, get) => {
         normalizationEnabled,
         normalizationTargetLufs,
         replayGainScanEnabled: replayGainEnabled,
-        replayGainMode
+        replayGainMode,
+        fadeEnabled,
+        fadeInDurationMs,
+        fadeOutDurationMs,
+        crossfadeEnabled,
+        crossfadeDurationMs
       })
 
       await get().refreshDevices()

--- a/src/renderer/stores/libraryNavigation.test.ts
+++ b/src/renderer/stores/libraryNavigation.test.ts
@@ -23,6 +23,7 @@ function makeDbTrack(path: string, artist = 'Artist A'): DbTrack {
     track_number: 1,
     disc_number: 1,
     year: 2026,
+    date: null,
     genre: null,
     genres: [],
     artwork_hash: null,

--- a/src/renderer/stores/libraryStore.test.ts
+++ b/src/renderer/stores/libraryStore.test.ts
@@ -26,6 +26,7 @@ function makeTrack(path: string, overrides: Partial<DbTrack> = {}): DbTrack {
     track_number: overrides.track_number ?? 1,
     disc_number: overrides.disc_number ?? 1,
     year: overrides.year ?? 2026,
+    date: overrides.date ?? null,
     genre: overrides.genre ?? null,
     genres: overrides.genres ?? (overrides.genre ? [overrides.genre] : []),
     artwork_hash: overrides.artwork_hash ?? null,
@@ -68,6 +69,7 @@ interface MockLibraryApi {
   getFavoritePaths: () => Promise<string[]> | string[]
   getFavorites: () => Promise<DbTrack[]> | DbTrack[]
   getRecentlyPlayed: (limit: number) => Promise<DbTrack[]> | DbTrack[]
+  getArtistSplitExceptions: () => Promise<string[]> | string[]
 }
 
 function installMockLibraryApi(overrides: Partial<MockLibraryApi> = {}): void {
@@ -82,6 +84,7 @@ function installMockLibraryApi(overrides: Partial<MockLibraryApi> = {}): void {
     getFavoritePaths: async () => [],
     getFavorites: async () => [],
     getRecentlyPlayed: async () => [],
+    getArtistSplitExceptions: async () => [],
     ...overrides
   }
 

--- a/src/renderer/stores/libraryStore.ts
+++ b/src/renderer/stores/libraryStore.ts
@@ -3,6 +3,7 @@ import type { TrackSourceType } from '../../types/subsonic'
 import { logMemoryDiagnosticsEvent } from '../utils/memoryDiagnostics'
 import { useUIStore } from './uiStore'
 import {
+  ALBUM_GRID_YEAR_VISIBILITY_STORAGE_KEY,
   ALBUM_SORT_MODE_STORAGE_KEY,
   ARTIST_BROWSE_MODE_STORAGE_KEY,
   ARTIST_ROOT_VIEW_MODE_STORAGE_KEY,
@@ -23,6 +24,8 @@ import {
 import { normalizeKey } from '../utils/albumIdentity'
 import { albumMatchesLibraryYear, type LibraryYearKey } from '../utils/libraryYears'
 
+export const ARTIST_SPLIT_EXCEPTIONS_PENDING_RESTART_STORAGE_KEY = 'astra-artist-split-exceptions-pending-restart'
+
 // Types matching preload
 export interface DbTrack {
   id: number
@@ -39,6 +42,7 @@ export interface DbTrack {
   track_number: number | null
   disc_number: number | null
   year: number | null
+  date: string | null
   genre: string | null
   genres: string[]
   artwork_hash: string | null
@@ -86,7 +90,7 @@ interface Artist {
   primary_track_count: number
   album_count: number
   artwork_hash: string | null
-  artwork_source: 'manual' | 'detected' | 'track' | null
+  artwork_source: 'manual' | 'remote' | 'detected' | 'track' | null
 }
 
 interface Genre {
@@ -224,6 +228,8 @@ interface LibraryStore {
   folderWarnings: Record<string, string[]>
   lastScanIssueLog: ScanIssueLog | null
   folderSubfolderSummaries: Record<string, FolderSubfolderSummary>
+  artistSplitExceptions: string[]
+  artistSplitExceptionsRestartConfirmation: string
   favorites: Set<string>
   favoriteTrackPaths: string[]
   recentlyPlayedPaths: string[]
@@ -232,6 +238,7 @@ interface LibraryStore {
   showTracklistGenre: boolean
   showTracklistAddedDate: boolean
   showTracklistPlayCount: boolean
+  showAlbumGridYear: boolean
   trackListSortState: LibraryTrackListSortState | null
   tracksViewSortState: LibraryTrackListSortState | null
   selectedSourceFilters: Set<string>
@@ -262,6 +269,10 @@ interface LibraryStore {
     relativePath: string,
     excluded: boolean
   ) => Promise<FolderSubfolderSummary | null>
+  loadArtistSplitExceptions: () => Promise<void>
+  addArtistSplitException: (name: string) => Promise<void>
+  removeArtistSplitException: (name: string) => Promise<void>
+  setArtistSplitExceptionsRestartConfirmation: (message: string) => void
   rescanFolder: (folderPath: string) => Promise<FolderSubfolderSummary | null>
   scanFolders: (folderPaths: string[]) => Promise<{ scannedFolders: number; canceled: boolean }>
   cancelScan: () => Promise<boolean>
@@ -302,6 +313,7 @@ interface LibraryStore {
   setShowTracklistGenre: (enabled: boolean) => void
   setShowTracklistAddedDate: (enabled: boolean) => void
   setShowTracklistPlayCount: (enabled: boolean) => void
+  setShowAlbumGridYear: (enabled: boolean) => void
   setTrackListSortState: (sortState: LibraryTrackListSortState | null) => void
   resetTrackListSortState: () => void
   setSelectedSourceFilters: (filters: Iterable<string>) => void
@@ -676,6 +688,16 @@ function loadTracklistPlayCountVisibilitySetting(): boolean {
   }
 }
 
+// Year was always shown on album cards before this became toggleable, so — unlike the tracklist
+// column flags above, which are new and default off — an absent/missing key here means "on".
+function loadAlbumGridYearVisibilitySetting(): boolean {
+  try {
+    return localStorage.getItem(ALBUM_GRID_YEAR_VISIBILITY_STORAGE_KEY) !== '0'
+  } catch {
+    return true
+  }
+}
+
 function normalizeArtistBrowseMode(mode: LibraryArtistBrowseMode | string | null | undefined): LibraryArtistBrowseMode {
   return mode === 'strict' ? 'strict' : 'canonical'
 }
@@ -947,6 +969,8 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
   folderWarnings: {},
   lastScanIssueLog: null,
   folderSubfolderSummaries: {},
+  artistSplitExceptions: [],
+  artistSplitExceptionsRestartConfirmation: '',
   favorites: new Set<string>(),
   favoriteTrackPaths: [],
   recentlyPlayedPaths: [],
@@ -955,6 +979,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
   showTracklistGenre: loadTracklistGenreVisibilitySetting(),
   showTracklistAddedDate: loadTracklistAddedDateVisibilitySetting(),
   showTracklistPlayCount: loadTracklistPlayCountVisibilitySetting(),
+  showAlbumGridYear: loadAlbumGridYearVisibilitySetting(),
   trackListSortState: { ...DEFAULT_TRACK_LIST_SORT_STATE },
   tracksViewSortState: { ...DEFAULT_TRACK_LIST_SORT_STATE },
   selectedSourceFilters: new Set<string>(),
@@ -984,6 +1009,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       get().loadArtists(),
       get().loadGenres(),
       get().loadFolders(),
+      get().loadArtistSplitExceptions(),
       get().loadFavorites(),
       get().loadRecentlyPlayed(),
       currentSelection.hasFullTrackConsumers ? get().loadFullTracks() : Promise.resolve()
@@ -1258,6 +1284,31 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     }
 
     return result.summary ?? null
+  },
+
+  loadArtistSplitExceptions: async () => {
+    const artistSplitExceptions = await window.electronAPI.library.getArtistSplitExceptions()
+    set({ artistSplitExceptions })
+  },
+
+  addArtistSplitException: async (name: string) => {
+    const success = await window.electronAPI.library.addArtistSplitException(name)
+    if (success) {
+      persistBooleanPreference(ARTIST_SPLIT_EXCEPTIONS_PENDING_RESTART_STORAGE_KEY, true)
+    }
+    await get().loadArtistSplitExceptions()
+  },
+
+  removeArtistSplitException: async (name: string) => {
+    const success = await window.electronAPI.library.removeArtistSplitException(name)
+    if (success) {
+      persistBooleanPreference(ARTIST_SPLIT_EXCEPTIONS_PENDING_RESTART_STORAGE_KEY, true)
+    }
+    await get().loadArtistSplitExceptions()
+  },
+
+  setArtistSplitExceptionsRestartConfirmation: (message: string) => {
+    set({ artistSplitExceptionsRestartConfirmation: message })
   },
 
   // Rescan one folder after a batch of subfolder inclusion/exclusion changes.
@@ -2158,6 +2209,17 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
 
     try {
       localStorage.setItem(TRACKLIST_PLAY_COUNT_VISIBILITY_STORAGE_KEY, normalized ? '1' : '0')
+    } catch {
+      // Ignore localStorage write failures in restricted environments.
+    }
+  },
+
+  setShowAlbumGridYear: (enabled: boolean) => {
+    const normalized = Boolean(enabled)
+    set({ showAlbumGridYear: normalized })
+
+    try {
+      localStorage.setItem(ALBUM_GRID_YEAR_VISIBILITY_STORAGE_KEY, normalized ? '1' : '0')
     } catch {
       // Ignore localStorage write failures in restricted environments.
     }

--- a/src/renderer/stores/playerStore.test.ts
+++ b/src/renderer/stores/playerStore.test.ts
@@ -78,6 +78,7 @@ function makeDbTrack(path: string, overrides: Partial<DbTrack> = {}): DbTrack {
     track_number: overrides.track_number ?? 1,
     disc_number: overrides.disc_number ?? 1,
     year: overrides.year ?? 2026,
+    date: overrides.date ?? null,
     genre: overrides.genre ?? null,
     genres: overrides.genres ?? (overrides.genre ? [overrides.genre] : []),
     artwork_hash: overrides.artwork_hash ?? null,

--- a/src/renderer/stores/playerStore.ts
+++ b/src/renderer/stores/playerStore.ts
@@ -485,6 +485,7 @@ function dbTrackToTrack(dbTrack: DbTrack): Track {
     trackNumber: dbTrack.track_number ?? undefined,
     discNumber: dbTrack.disc_number ?? undefined,
     year: dbTrack.year ?? undefined,
+    date: dbTrack.date ?? undefined,
     genre: dbTrack.genre ?? undefined,
     genres: dbTrack.genres,
     artworkHash: dbTrack.artwork_hash ?? undefined,
@@ -542,6 +543,11 @@ export async function createQueueEntriesFromPathsWithFetch(trackPaths: readonly 
   return createQueueEntriesFromResolvedTracks(paths, resolvedTracks)
 }
 
+// Paths for which resolveQueueEntryTrack has already kicked off a background cache refresh —
+// avoids firing a duplicate getTracksByPaths IPC call every time the same still-missing entry is
+// resolved again (several call sites iterate the queue in a loop).
+const pendingQueueTrackRefreshPaths = new Set<string>()
+
 function resolveQueueEntryTrack(entry: QueueTrackEntry | null | undefined): Track | null {
   if (!entry) return null
 
@@ -550,7 +556,35 @@ function resolveQueueEntryTrack(entry: QueueTrackEntry | null | undefined): Trac
   }
 
   const [dbTrack] = useLibraryStore.getState().resolveTrackPaths([entry.path])
-  const track = dbTrack ? dbTrackToTrack(dbTrack) : { ...entry.snapshot }
+  let track: Track
+  if (dbTrack) {
+    track = dbTrackToTrack(dbTrack)
+  } else {
+    // Cache miss: trackByPath is a synchronous in-memory lookup, not a live DB read, so this can
+    // happen before the library finishes loading (or if this path was never indexed yet). Falling
+    // back to the queued snapshot silently risks a stale/minimal Track — e.g.
+    // createFallbackQueueTrackSnapshot's duration: 0 and missing sampleRate, which can send this
+    // track down a different code path (see shouldUseLocalProgressivePath) than a fresh DB read
+    // would. Surface it loudly, and warm the cache in the background so the next resolution of
+    // this path is accurate even though this call still has to return the fallback now.
+    track = { ...entry.snapshot }
+    console.warn(
+      `resolveQueueEntryTrack: "${entry.path}" is not in the in-memory library cache yet — ` +
+      `falling back to the queued snapshot (duration=${entry.snapshot.duration}, ` +
+      `sampleRate=${entry.snapshot.sampleRate ?? 'unset'}) instead of a fresh DB read.`
+    )
+    if (!pendingQueueTrackRefreshPaths.has(entry.path)) {
+      pendingQueueTrackRefreshPaths.add(entry.path)
+      const refreshPath = entry.path
+      void useLibraryStore.getState().resolveTrackPathsWithFetch([refreshPath])
+        .catch((error) => {
+          console.error(`resolveQueueEntryTrack: background cache refresh failed for "${refreshPath}":`, error)
+        })
+        .finally(() => {
+          pendingQueueTrackRefreshPaths.delete(refreshPath)
+        })
+    }
+  }
 
   if (entry.snapshot.isAvailable === false) {
     return {
@@ -896,12 +930,30 @@ async function shouldUseLocalProgressivePath(track: Track): Promise<boolean> {
   if (useAudioSettingsStore.getState().playbackOutputMode !== 'standard') return false
 
   const estimatedDecodedBytes = estimateDecodedTrackBytes(track)
+  console.log('[DEBUG] shouldUseLocalProgressivePath', {
+    trackPath: track.path,
+    duration: track.duration,
+    sampleRate: track.sampleRate,
+    estimatedDecodedBytes
+  })
   if (estimatedDecodedBytes !== null && estimatedDecodedBytes >= LOCAL_PROGRESSIVE_DECODED_BYTES) {
+    console.log('[DEBUG] shouldUseLocalProgressivePath result', {
+      trackPath: track.path,
+      result: true,
+      decidedVia: 'decoded-bytes-estimate'
+    })
     return true
   }
 
   const fileStat = await window.electronAPI.getAudioFileStat(track.path).catch(() => null)
-  return Boolean(fileStat && fileStat.size >= LARGE_LOCAL_FILE_BYTES)
+  const result = Boolean(fileStat && fileStat.size >= LARGE_LOCAL_FILE_BYTES)
+  console.log('[DEBUG] shouldUseLocalProgressivePath result', {
+    trackPath: track.path,
+    result,
+    decidedVia: 'file-size-fallback',
+    fileSize: fileStat?.size ?? null
+  })
+  return result
 }
 
 function scheduleDeferredWaveformExtraction(callback: () => void): void {

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -28,6 +28,16 @@ export const DEFAULT_UI_SCALE_PERCENT = 100
 export const MAX_UI_SCALE_PERCENT = 125
 export const UI_SCALE_STEP_PERCENT = 5
 export const UI_SCALE_STORAGE_KEY = 'astra-ui-scale-percent-v1'
+export const MIN_ALBUM_GRID_SCALE_PERCENT = 50
+export const DEFAULT_ALBUM_GRID_SCALE_PERCENT = 100
+export const MAX_ALBUM_GRID_SCALE_PERCENT = 200
+export const ALBUM_GRID_SCALE_STEP_PERCENT = 10
+export const ALBUM_GRID_SCALE_STORAGE_KEY = 'astra-album-grid-scale-percent-v1'
+export const MIN_ARTIST_GRID_SCALE_PERCENT = 50
+export const DEFAULT_ARTIST_GRID_SCALE_PERCENT = 100
+export const MAX_ARTIST_GRID_SCALE_PERCENT = 200
+export const ARTIST_GRID_SCALE_STEP_PERCENT = 10
+export const ARTIST_GRID_SCALE_STORAGE_KEY = 'astra-artist-grid-scale-percent-v1'
 export const HOME_GREETING_TEXT_MODE_STORAGE_KEY = 'astra-home-greeting-text-mode-v1'
 export const DEFAULT_HOME_GREETING_TEXT_MODE: HomeGreetingTextMode = 'messages'
 export const ACTIVITY_INDICATOR_EXPERIMENT_STORAGE_KEY = 'astra-experimental-activity-indicator-enabled-v1'
@@ -194,6 +204,28 @@ export function getNextUIScalePercent(currentPercent: number, action: UIScaleSho
   return normalizeUIScalePercent(currentPercent + delta)
 }
 
+export function normalizeAlbumGridScalePercent(value: unknown): number {
+  if (value == null) return DEFAULT_ALBUM_GRID_SCALE_PERCENT
+  if (typeof value === 'string' && value.trim().length === 0) return DEFAULT_ALBUM_GRID_SCALE_PERCENT
+
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return DEFAULT_ALBUM_GRID_SCALE_PERCENT
+
+  const snapped = Math.round(numeric / ALBUM_GRID_SCALE_STEP_PERCENT) * ALBUM_GRID_SCALE_STEP_PERCENT
+  return Math.min(MAX_ALBUM_GRID_SCALE_PERCENT, Math.max(MIN_ALBUM_GRID_SCALE_PERCENT, snapped))
+}
+
+export function normalizeArtistGridScalePercent(value: unknown): number {
+  if (value == null) return DEFAULT_ARTIST_GRID_SCALE_PERCENT
+  if (typeof value === 'string' && value.trim().length === 0) return DEFAULT_ARTIST_GRID_SCALE_PERCENT
+
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return DEFAULT_ARTIST_GRID_SCALE_PERCENT
+
+  const snapped = Math.round(numeric / ARTIST_GRID_SCALE_STEP_PERCENT) * ARTIST_GRID_SCALE_STEP_PERCENT
+  return Math.min(MAX_ARTIST_GRID_SCALE_PERCENT, Math.max(MIN_ARTIST_GRID_SCALE_PERCENT, snapped))
+}
+
 export function normalizeHomeGreetingTextMode(value: unknown): HomeGreetingTextMode {
   return value === 'clock' || value === 'off' || value === 'messages'
     ? value
@@ -272,6 +304,38 @@ function readUIScalePreference(): number {
 function persistUIScalePreference(percent: number): void {
   try {
     localStorage.setItem(UI_SCALE_STORAGE_KEY, String(normalizeUIScalePercent(percent)))
+  } catch {
+    // Ignore storage failures and continue with in-memory preference.
+  }
+}
+
+function readAlbumGridScalePreference(): number {
+  try {
+    return normalizeAlbumGridScalePercent(localStorage.getItem(ALBUM_GRID_SCALE_STORAGE_KEY))
+  } catch {
+    return DEFAULT_ALBUM_GRID_SCALE_PERCENT
+  }
+}
+
+function persistAlbumGridScalePreference(percent: number): void {
+  try {
+    localStorage.setItem(ALBUM_GRID_SCALE_STORAGE_KEY, String(normalizeAlbumGridScalePercent(percent)))
+  } catch {
+    // Ignore storage failures and continue with in-memory preference.
+  }
+}
+
+function readArtistGridScalePreference(): number {
+  try {
+    return normalizeArtistGridScalePercent(localStorage.getItem(ARTIST_GRID_SCALE_STORAGE_KEY))
+  } catch {
+    return DEFAULT_ARTIST_GRID_SCALE_PERCENT
+  }
+}
+
+function persistArtistGridScalePreference(percent: number): void {
+  try {
+    localStorage.setItem(ARTIST_GRID_SCALE_STORAGE_KEY, String(normalizeArtistGridScalePercent(percent)))
   } catch {
     // Ignore storage failures and continue with in-memory preference.
   }
@@ -436,6 +500,8 @@ const initialWaveformTimeDisplayMode = readWaveformTimeDisplayModePreference()
 const initialAnalyzerHeightPx = readAnalyzerHeightPreference()
 const initialAnalyzerRackVisible = readAnalyzerRackVisibilityPreference()
 const initialUIScalePercent = readUIScalePreference()
+const initialAlbumGridScalePercent = readAlbumGridScalePreference()
+const initialArtistGridScalePercent = readArtistGridScalePreference()
 const initialHomeGreetingTextMode = readHomeGreetingTextModePreference()
 const initialActivityIndicatorExperimentEnabled = readActivityIndicatorExperimentPreference()
 const initialControllerSupportEnabled = readControllerSupportExperimentPreference()
@@ -475,6 +541,8 @@ interface UIStore {
   isZoneDisplayActive: boolean
   analyzerHeightPx: number
   uiScalePercent: number
+  albumGridScalePercent: number
+  artistGridScalePercent: number
   homeGreetingTextMode: HomeGreetingTextMode
   activityIndicatorExperimentEnabled: boolean
   controllerSupportEnabled: boolean
@@ -521,6 +589,10 @@ interface UIStore {
   resetAnalyzerRackPreferences: () => void
   setUIScalePercent: (percent: number) => void
   resetUIScalePercent: () => void
+  setAlbumGridScalePercent: (percent: number) => void
+  resetAlbumGridScalePercent: () => void
+  setArtistGridScalePercent: (percent: number) => void
+  resetArtistGridScalePercent: () => void
   setHomeGreetingTextMode: (mode: HomeGreetingTextMode) => void
   resetHomeGreetingTextMode: () => void
   setActivityIndicatorExperimentEnabled: (enabled: boolean) => void
@@ -578,6 +650,8 @@ export const useUIStore = create<UIStore>((set, get) => ({
   isZoneDisplayActive: initialIsZoneDisplayActive,
   analyzerHeightPx: initialAnalyzerHeightPx,
   uiScalePercent: initialUIScalePercent,
+  albumGridScalePercent: initialAlbumGridScalePercent,
+  artistGridScalePercent: initialArtistGridScalePercent,
   homeGreetingTextMode: initialHomeGreetingTextMode,
   activityIndicatorExperimentEnabled: initialActivityIndicatorExperimentEnabled,
   controllerSupportEnabled: initialControllerSupportEnabled,
@@ -754,6 +828,24 @@ export const useUIStore = create<UIStore>((set, get) => ({
   resetUIScalePercent: () => {
     persistUIScalePreference(DEFAULT_UI_SCALE_PERCENT)
     set({ uiScalePercent: DEFAULT_UI_SCALE_PERCENT })
+  },
+  setAlbumGridScalePercent: (percent) => {
+    const nextScalePercent = normalizeAlbumGridScalePercent(percent)
+    persistAlbumGridScalePreference(nextScalePercent)
+    set({ albumGridScalePercent: nextScalePercent })
+  },
+  resetAlbumGridScalePercent: () => {
+    persistAlbumGridScalePreference(DEFAULT_ALBUM_GRID_SCALE_PERCENT)
+    set({ albumGridScalePercent: DEFAULT_ALBUM_GRID_SCALE_PERCENT })
+  },
+  setArtistGridScalePercent: (percent) => {
+    const nextScalePercent = normalizeArtistGridScalePercent(percent)
+    persistArtistGridScalePreference(nextScalePercent)
+    set({ artistGridScalePercent: nextScalePercent })
+  },
+  resetArtistGridScalePercent: () => {
+    persistArtistGridScalePreference(DEFAULT_ARTIST_GRID_SCALE_PERCENT)
+    set({ artistGridScalePercent: DEFAULT_ARTIST_GRID_SCALE_PERCENT })
   },
   setHomeGreetingTextMode: (mode) => {
     const nextMode = normalizeHomeGreetingTextMode(mode)

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -1690,6 +1690,20 @@ html.app-view-transition-up::view-transition-new(app-main-view) {
   white-space: nowrap;
 }
 
+.info-meta-value--wrap {
+  overflow: visible;
+  text-overflow: unset;
+  white-space: normal;
+}
+
+.info-meta-value--clickable {
+  cursor: pointer;
+}
+
+.info-meta-value--clickable:hover {
+  color: var(--text-primary);
+}
+
 .info-meta-album-link {
   appearance: none;
   border: 0;
@@ -1913,6 +1927,51 @@ html.app-view-transition-up::view-transition-new(app-main-view) {
   color: var(--text-secondary);
   padding-right: 4px;
   font-family: inherit;
+}
+
+.info-bio-panel {
+  min-height: 0;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 10px;
+  overflow: hidden;
+}
+
+.info-bio-artwork {
+  width: 100%;
+  aspect-ratio: 1;
+  min-height: 200px;
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--glass-border);
+}
+
+.info-bio-artwork img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.info-bio-name {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.info-bio-text {
+  margin: 0;
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  padding-right: 4px;
 }
 
 /* ============================================
@@ -7551,6 +7610,7 @@ body:has(.fullscreen-overlay) .controller-hints {
   --artist-row-height: 64px;
   --artist-grid-min-column-width: 124px;
   --artist-grid-row-height: 168px;
+  --artist-grid-avatar-height: 96px;
   --artist-grid-gap: 12px;
   flex: 1;
   min-width: 0;
@@ -7686,7 +7746,7 @@ body:has(.fullscreen-overlay) .controller-hints {
 
 .artist-grid-avatar {
   width: 100%;
-  height: 96px;
+  height: var(--artist-grid-avatar-height);
   border-radius: 7px;
   border: 1px solid rgba(var(--tint), 0.08);
   background: var(--bg-tertiary);
@@ -13912,6 +13972,14 @@ html[data-theme-tone="light"] .transport-center {
   stroke: rgba(var(--tint), 0.66);
 }
 
+.transport-eq-graphic-slot {
+  width: 56px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .transport-eq-curve {
   width: 56px;
   height: 28px;
@@ -13929,6 +13997,10 @@ html[data-theme-tone="light"] .transport-center {
 
 .transport-eq-curve .eq-response-preview-fill {
   fill: transparent;
+}
+
+.transport-eq-btn:disabled {
+  cursor: not-allowed;
 }
 
 .transport-eq-btn,
@@ -16635,6 +16707,7 @@ html.library-tab-transition-backward::view-transition-new(library-tab-content) {
   .artist-list {
     --artist-grid-min-column-width: 112px;
     --artist-grid-row-height: 154px;
+    --artist-grid-avatar-height: 88px;
     --artist-grid-gap: 10px;
   }
 
@@ -16644,7 +16717,6 @@ html.library-tab-transition-backward::view-transition-new(library-tab-content) {
   }
 
   .artist-grid-avatar {
-    height: 88px;
     font-size: 26px;
   }
 
@@ -18685,6 +18757,12 @@ html.library-tab-transition-backward::view-transition-new(library-tab-content) {
   gap: 8px;
 }
 
+.settings-shell .settings-artist-split-exception-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .settings-lastfm-profiles-field {
   gap: 10px;
 }
@@ -18896,6 +18974,21 @@ html.library-tab-transition-backward::view-transition-new(library-tab-content) {
 .settings-shell .settings-scale-value {
   min-width: 56px;
   justify-content: center;
+}
+
+.settings-shell .settings-grid-scale-preview {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 12px;
+  padding-top: 4px;
+  overflow-x: auto;
+  overflow-y: auto;
+}
+
+.settings-shell .settings-grid-scale-preview > .album-card,
+.settings-shell .settings-grid-scale-preview > .artist-grid-card {
+  flex-shrink: 0;
 }
 
 .settings-shell .settings-remote-url-list {

--- a/src/renderer/types/audio.ts
+++ b/src/renderer/types/audio.ts
@@ -14,6 +14,7 @@ export interface Track {
   trackNumber?: number
   discNumber?: number
   year?: number
+  date?: string
   genre?: string
   genres?: string[]
   artworkData?: string  // Base64 data URL fallback for uncached direct artwork

--- a/src/renderer/utils/artistMetadata.ts
+++ b/src/renderer/utils/artistMetadata.ts
@@ -1,3 +1,5 @@
+import { normalizeKey } from '../../shared/library/albumGrouping.ts'
+
 export interface ArtistToken {
   artist: string
   separator: string | null
@@ -9,9 +11,13 @@ function normalizeArtistText(value: string): string {
   return value.replace(/\s+/g, ' ').trim()
 }
 
-export function parseArtistMetadata(artistText: string): ArtistToken[] {
+export function parseArtistMetadata(artistText: string, exceptions: string[] = []): ArtistToken[] {
   const normalized = normalizeArtistText(artistText)
   if (!normalized) return []
+
+  if (exceptions.some((exception) => normalizeKey(exception) === normalizeKey(normalized))) {
+    return [{ artist: normalized, separator: null }]
+  }
 
   const parts = normalized.split(SEPARATOR_SPLIT_PATTERN)
   const tokens: ArtistToken[] = []

--- a/src/renderer/utils/libraryGraph.ts
+++ b/src/renderer/utils/libraryGraph.ts
@@ -156,7 +156,7 @@ interface RelaxLayoutOptions {
   fixedNodeKeys?: Set<string>
 }
 
-const artistGraphBuildCache = new WeakMap<readonly ArtistGraphTrackLike[], ArtistGraphBuildResult>()
+const artistGraphBuildCache = new WeakMap<readonly ArtistGraphTrackLike[], Map<string, ArtistGraphBuildResult>>()
 const artistGraphIndexCache = new WeakMap<ArtistGraphBuildResult, ArtistGraphIndex>()
 const artistGraphVisibleCache = new WeakMap<ArtistGraphBuildResult, Map<string, ArtistGraphVisibleResult>>()
 const artistGraphLayoutCache = new WeakMap<ArtistGraphVisibleResult, Map<string, ArtistGraphLayoutResult>>()
@@ -179,7 +179,7 @@ function isIgnorableArtist(displayArtist: string): boolean {
   return artistKey != null && GENERIC_ARTIST_KEYS.has(artistKey)
 }
 
-function toTrackParticipants(track: ArtistGraphTrackLike): Map<string, string> {
+function toTrackParticipants(track: ArtistGraphTrackLike, exceptions: string[] = []): Map<string, string> {
   const participants = new Map<string, string>()
   let sawIgnorableArtist = false
 
@@ -187,7 +187,7 @@ function toTrackParticipants(track: ArtistGraphTrackLike): Map<string, string> {
     const normalized = normalizeDisplay(rawValue ?? '')
     if (!normalized) return
 
-    const split = splitCollaborators(normalized)
+    const split = splitCollaborators(normalized, exceptions)
     const values = split.length > 0 ? split : [normalized]
     for (const value of values) {
       const display = normalizeDisplay(value)
@@ -357,8 +357,10 @@ export function indexArtistGraph(graph: ArtistGraphBuildResult): ArtistGraphInde
   return index
 }
 
-export function buildArtistGraph(tracks: readonly ArtistGraphTrackLike[]): ArtistGraphBuildResult {
-  const cached = artistGraphBuildCache.get(tracks)
+export function buildArtistGraph(tracks: readonly ArtistGraphTrackLike[], exceptions: string[] = []): ArtistGraphBuildResult {
+  const exceptionsKey = JSON.stringify(exceptions)
+  const cachedByExceptions = artistGraphBuildCache.get(tracks)
+  const cached = cachedByExceptions?.get(exceptionsKey)
   if (cached) {
     return cached
   }
@@ -367,7 +369,7 @@ export function buildArtistGraph(tracks: readonly ArtistGraphTrackLike[]): Artis
   const edgeAccumulators = new Map<string, ArtistGraphEdgeAccumulator>()
 
   for (const track of tracks) {
-    const participants = toTrackParticipants(track)
+    const participants = toTrackParticipants(track, exceptions)
     const participantEntries = Array.from(participants.entries())
     const releaseIdentityKey = getReleaseIdentityKey(track)
     const albumName = getTrackAlbumName(track)
@@ -505,7 +507,11 @@ export function buildArtistGraph(tracks: readonly ArtistGraphTrackLike[]): Artis
     maxEdgeWeight: edges.reduce((maxEdgeWeight, edge) => Math.max(maxEdgeWeight, edge.sharedTrackCount), 0)
   }
 
-  artistGraphBuildCache.set(tracks, result)
+  if (cachedByExceptions) {
+    cachedByExceptions.set(exceptionsKey, result)
+  } else {
+    artistGraphBuildCache.set(tracks, new Map([[exceptionsKey, result]]))
+  }
   return result
 }
 

--- a/src/renderer/utils/sessionState.ts
+++ b/src/renderer/utils/sessionState.ts
@@ -45,6 +45,7 @@ export interface SessionQueueTrackSnapshot {
   trackNumber?: number
   discNumber?: number
   year?: number
+  date?: string
   genre?: string
   genres?: string[]
   artworkHash?: string
@@ -56,6 +57,7 @@ export interface SessionQueueTrackSnapshot {
   codec?: string
   codecProfile?: string
   isAtmosJoc?: boolean
+  isIamf?: boolean
   replayGainTrackDb?: number
   replayGainAlbumDb?: number
   sourceType?: TrackSourceType
@@ -336,6 +338,7 @@ function normalizeQueueTrackSnapshot(value: unknown): SessionQueueTrackSnapshot 
     ...(trackNumber !== undefined ? { trackNumber } : {}),
     ...(discNumber !== undefined ? { discNumber } : {}),
     ...(year !== undefined ? { year } : {}),
+    ...(optionalString(value.date) ? { date: optionalString(value.date) } : {}),
     ...(optionalString(value.genre) ? { genre: optionalString(value.genre) } : {}),
     ...(stringArray(value.genres) ? { genres: stringArray(value.genres) } : {}),
     ...(optionalString(value.artworkHash) ? { artworkHash: optionalString(value.artworkHash) } : {}),
@@ -347,6 +350,7 @@ function normalizeQueueTrackSnapshot(value: unknown): SessionQueueTrackSnapshot 
     ...(optionalString(value.codec) ? { codec: optionalString(value.codec) } : {}),
     ...(optionalString(value.codecProfile) ? { codecProfile: optionalString(value.codecProfile) } : {}),
     ...(typeof value.isAtmosJoc === 'boolean' ? { isAtmosJoc: value.isAtmosJoc } : {}),
+    ...(typeof value.isIamf === 'boolean' ? { isIamf: value.isIamf } : {}),
     ...(replayGainTrackDb !== undefined ? { replayGainTrackDb } : {}),
     ...(replayGainAlbumDb !== undefined ? { replayGainAlbumDb } : {}),
     ...(sourceType ? { sourceType } : {}),

--- a/src/shared/library/albumGrouping.ts
+++ b/src/shared/library/albumGrouping.ts
@@ -57,9 +57,13 @@ export function normalizeArtworkHash(hash: string | null | undefined): string | 
   return normalized ? normalized.toLocaleLowerCase() : null
 }
 
-export function splitCollaborators(rawArtist: string): string[] {
+export function splitCollaborators(rawArtist: string, exceptions: string[] = []): string[] {
   const normalized = normalizeDisplay(rawArtist)
   if (!normalized) return []
+
+  if (exceptions.some((exception) => normalizeKey(exception) === normalizeKey(normalized))) {
+    return [normalized]
+  }
 
   const unified = normalized
     .replace(/\s*;\s*/g, ',')
@@ -79,8 +83,8 @@ export function splitCollaborators(rawArtist: string): string[] {
   return Array.from(unique.values())
 }
 
-export function getPrimaryArtistFromTrackArtist(trackArtist: string): string {
-  const contributors = splitCollaborators(trackArtist)
+export function getPrimaryArtistFromTrackArtist(trackArtist: string, exceptions: string[] = []): string {
+  const contributors = splitCollaborators(trackArtist, exceptions)
   return contributors[0] ?? UNKNOWN_ARTIST_NAME
 }
 

--- a/src/shared/library/trackSearch.ts
+++ b/src/shared/library/trackSearch.ts
@@ -1,0 +1,12 @@
+import { matchesFuzzyFields } from '../../renderer/utils/fuzzySearch'
+
+export function matchesTrackSearchQuery(
+  track: { title: string; artist: string; album: string },
+  query: string
+): boolean {
+  return matchesFuzzyFields(query, [
+    { value: track.title, weight: 1.5 },
+    { value: track.album, weight: 1.4 },
+    { value: track.artist, weight: 1.1 }
+  ])
+}

--- a/src/types/lastFm.ts
+++ b/src/types/lastFm.ts
@@ -86,6 +86,17 @@ export interface LastFmAuthFinishResult {
   message: string
 }
 
+export interface LastFmArtistInfo {
+  name: string
+  bio: string | null
+  tags: string[]
+  imageUrl: string | null
+}
+
+export type LastFmArtistInfoResult =
+  | { ok: true; artist: LastFmArtistInfo }
+  | { ok: false; message: string }
+
 export interface LastFmCustomProfileInput {
   protocol?: LastFmScrobbleProtocol
   name: string


### PR DESCRIPTION
## Summary
This PR bundles several features and bug fixes built while testing Astra. Happy to split into smaller PRs if that's easier to review.

## Features
- **Artist split exceptions** (Settings > Library): a user-editable list of full artist credits (e.g. "Tyler, The Creator") that should never be split into separate collaborators. Wired through every place in the codebase that splits artist names.
- **Playlist search**: search now works inside playlists too, not just the library/albums. Matches title, album, and artist.
- **Fade in/out & crossfade** (Settings > Playback): configurable fade-in/out durations and a crossfade between tracks, with per-track gain nodes. Automatically disabled in Bit-Perfect mode (DSP-incompatible), same pattern as EQ/Normalization.
- **Adjustable grid size** (Settings > Library): resize the album and artist grid cards, with a live preview. Includes a toggle to show/hide the release year on album cards.
- **Fuller genre info**: track info panel now shows all genres for a track, and genres display with commas instead of semicolons.
- **Release date field**: shows the full release date (not just year) when available in track metadata.
- **Artist bio tab** (Now Playing): shows artist bio via Last.fm.

## Bug fixes
- Release date on the resumed track was showing only the year after an app restart (incomplete session snapshot).
- Oscilloscope wasn't rendering in mini-player mode when the OS "reduce motion" accessibility setting was enabled.